### PR TITLE
removed restriction of defining iam-role and access key at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,18 @@ Here are the definitions of `aws` element's attributes and sub-elements:
 
 * `enabled`: Specifies whether the EC2 discovery is enabled or not, true or false.
 * `access-key`, `secret-key`: Access and secret keys of your account on EC2.
-* `iam-role`: If you do not want to use access key and secret key, you can specify `iam-role`. Hazelcast-aws plugin fetches your credentials by using your IAM role. It is optional. But when used, you should not provide the access/secret key pair.
+* `iam-role`: If you do not want to use access key and secret key, you can specify `iam-role`. Hazelcast-aws plugin fetches your credentials by using your IAM role. It is optional.
 * `region`: The region where your members are running. Default value is `us-east-1`. You need to specify this if the region is other than the default one.
 * `host-header`: The URL that is the entry point for a web service. It is optional.
 * `security-group-name`: Name of the security group you specified at the EC2 management console. It is used to narrow the Hazelcast members to be within this group. It is optional.
 * `tag-key`, `tag-value`: To narrow the members in the cloud down to only Hazelcast members, you can set these parameters as the ones you specified in the EC2 console. They are optional.
 * `connection-timeout-seconds`: The maximum amount of time Hazelcast will try to connect to a well known member before giving up. Setting this value too low could mean that a member is not able to connect to a cluster. Setting the value too high means that member startup could slow down because of longer timeouts (for example, when a well known member is not up). Increasing this value is recommended if you have many IPs listed and the members cannot properly build up the cluster. Its default value is 5.
 
+NOTE: If both iamrole and secretkey/accesskey are defined, hazelcast-aws will use iamrole to retrieve credentials and ignore defined secretkey/accesskey pair
+
 ## IAM Roles
 
-hazelcast-aws strongly recommends to use IAM Roles. access key and secret key should not be defined in the configuration although hazelcast-aws supports them. When `iam-role` tag defined in hazelcast configuration, hazelcast-aws fetches your credentials by using defined iam-role name. If you want to use iam-role assigned to your machine, you don't have to define anything. hazelcast-aws will automatically retrieve credentials using default iam-role. 
+hazelcast-aws strongly recommends to use IAM Roles. When `iam-role` tag defined in hazelcast configuration, hazelcast-aws fetches your credentials by using defined iam-role name. If you want to use iam-role assigned to your machine, you don't have to define anything. hazelcast-aws will automatically retrieve credentials using default iam-role.
 
 ### IAM Roles in ECS Environment
 

--- a/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
+++ b/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
@@ -79,13 +79,9 @@ public class DescribeInstances {
     }
 
     void checkKeysFromIamRoles(Environment env) throws IOException {
-        if (awsConfig.getAccessKey() != null && awsConfig.getIamRole() != null) {
-            throw new InvalidConfigurationException("You should only define one of `<iam-role>` and `<access-key>`");
-        }
-        if (awsConfig.getAccessKey() != null) {
+        if (awsConfig.getAccessKey() != null && awsConfig.getIamRole() == null) {
             return;
         }
-
         // in case no IAM role has been defined, this will attempt to retrieve name of default role.
         tryGetDefaultIamRole();
 

--- a/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
+++ b/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
@@ -124,21 +124,6 @@ public class DescribeInstancesTest {
         new DescribeInstances(awsConfig, "endpoint");
     }
 
-    @Test(expected = InvalidConfigurationException.class)
-    public void test_whenBoth_AccessKey_And_IamRole_Are_Defined() throws IOException {
-        Environment mockedEnv = mock(Environment.class);
-        when(mockedEnv.getEnvVar(Constants.ECS_CREDENTIALS_ENV_VAR_NAME)).thenReturn(null);
-
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setAccessKey("accesskey");
-        awsConfig.setSecretKey("secretkey");
-        awsConfig.setIamRole("someRole");
-
-        DescribeInstances descriptor = new DescribeInstances(awsConfig);
-        descriptor.checkKeysFromIamRoles(mockedEnv);
-    }
-
-
     @Test
     public void test_whenIamRoleExistsInConfig() throws IOException {
         final String someRole = "someRole";


### PR DESCRIPTION
It seems new ECS support PR has broken default behavior based on security definition so this PR restores it back.

fixes https://github.com/hazelcast/hazelcast-aws/issues/15