### PR TITLE
Add filtering attributes to the EC2 query

### DIFF
--- a/src/main/java/com/hazelcast/aws/impl/Constants.java
+++ b/src/main/java/com/hazelcast/aws/impl/Constants.java
@@ -19,7 +19,7 @@ package com.hazelcast.aws.impl;
 public final class Constants {
 
     public static final String DATE_FORMAT = "yyyyMMdd'T'HHmmss'Z'";
-    public static final String DOC_VERSION = "2014-06-15";
+    public static final String DOC_VERSION = "2016-11-15";
     public static final String SIGNATURE_METHOD_V4 = "AWS4-HMAC-SHA256";
     public static final String GET = "GET";
     public static final String ECS_CREDENTIALS_ENV_VAR_NAME = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";

--- a/src/main/java/com/hazelcast/aws/impl/Filter.java
+++ b/src/main/java/com/hazelcast/aws/impl/Filter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.aws.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Query filter to narrow down the scope of the queried EC2 instance set.
+ */
+public class Filter {
+
+    private Map<String, String> filters = new HashMap<String, String>();
+
+    /**
+     * Filter index, each filter need to have a sequential index, starting from 1.
+     */
+    private int index = 1;
+
+    /**
+     *
+     * Add a new filter with the given name and value to the query.
+     *
+     * @param name Filter name
+     * @param value Filter value
+     *
+     */
+    public void addFilter(String name, String value) {
+        filters.put("Filter." + index + ".Name", name);
+        filters.put("Filter." + index + ".Value.1", value);
+        ++index;
+    }
+
+    public Map<String, String> getFilters() {
+        return filters;
+    }
+}

--- a/src/test/java/com/hazelcast/aws/security/EC2RequestSignerTest.java
+++ b/src/test/java/com/hazelcast/aws/security/EC2RequestSignerTest.java
@@ -43,7 +43,7 @@ public class EC2RequestSignerTest {
     private final static String TEST_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
     private final static String TEST_REQUEST_DATE = "20141106T111126Z";
     private final static String TEST_DERIVED_EXPECTED = "7038265e40236063ebcd2e201908ad6e9f64e533439bfa7a5faa07ba419329bc";
-    private final static String TEST_SIGNATURE_EXPECTED = "c9347599958aab0ea079c296b8fe3355553bac767c5957dff7e7a1fce72ce132";
+    private final static String TEST_SIGNATURE_EXPECTED = "79f7a4d346ee69ca22ba5f9bc3dd1efc13ac7509936afc5ec21cac37de071eef";
 
     @Test(expected = IllegalArgumentException.class)
     public void whenConfigIsNull() {

--- a/src/test/java/com/hazelcast/aws/utility/CloudyUtilityTest.java
+++ b/src/test/java/com/hazelcast/aws/utility/CloudyUtilityTest.java
@@ -56,43 +56,14 @@ public class CloudyUtilityTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testNoTags() throws IOException {
+    public void testUnmarshalling() throws IOException {
         InputStream is = new ByteArrayInputStream(xml.getBytes());
         AwsConfig awsConfig1 = new AwsConfig();
         awsConfig1.setAccessKey("some-access-key");
         awsConfig1.setSecretKey("some-secret-key");
-        awsConfig1.setSecurityGroupName("hazelcast");
 
         Map<String, String> result = CloudyUtility.unmarshalTheResponse(is, awsConfig);
         assertEquals(2, result.size());
-    }
-
-    @Test
-    public void testTagsBothNodeHave() throws IOException {
-        InputStream is = new ByteArrayInputStream(xml.getBytes());
-        AwsConfig awsConfig1 = new AwsConfig();
-        awsConfig1.setAccessKey("some-access-key");
-        awsConfig1.setSecretKey("some-secret-key");
-        awsConfig1.setSecurityGroupName("hazelcast");
-        awsConfig.setTagKey("Name1");
-        awsConfig.setTagValue("value1");
-
-        Map<String, String> result = CloudyUtility.unmarshalTheResponse(is, awsConfig);
-        assertEquals(2, result.size());
-    }
-
-    @Test
-    public void testTagOnlyOneNodeHave() throws IOException {
-        InputStream is = new ByteArrayInputStream(xml.getBytes());
-        AwsConfig awsConfig1 = new AwsConfig();
-        awsConfig1.setAccessKey("some-access-key");
-        awsConfig1.setSecretKey("some-secret-key");
-        awsConfig1.setSecurityGroupName("hazelcast");
-        awsConfig.setTagKey("name");
-        awsConfig.setTagValue("");
-
-        Map<String, String> result = CloudyUtility.unmarshalTheResponse(is, awsConfig);
-        assertEquals(1, result.size());
     }
 
     @Test


### PR DESCRIPTION
Tag, security group and instance state was being filtered from the incoming response manually.
I've added these filtering params to the `DescribeInstances` API call so that it's not needed to do filtering manually after query. The response will be already filtered.