### PR TITLE
Add AWS request filtering based on tag value

### DIFF
--- a/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
+++ b/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
@@ -244,6 +244,8 @@ public class DescribeInstances {
             } else {
                 filter.addFilter("tag-key", awsConfig.getTagKey());
             }
+        } else if (!isNullOrEmpty(awsConfig.getTagValue())) {
+            filter.addFilter("tag-value", awsConfig.getTagValue());
         }
 
         if (!isNullOrEmpty(awsConfig.getSecurityGroupName())) {


### PR DESCRIPTION
Adds the filtering based on tag value even when the tag key is not provided.