### PR TITLE
Add info about iam-role and client outside AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Following are example declarative and programmatic configuration snippets:
         properties.put("security-group-name","hazelcast");
         properties.put("tag-key","aws-test-cluster");
         properties.put("tag-value","cluster1");
-        properties.put("hzPort","5701");
+        properties.put("hz-port","5701");
         DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(awsDiscoveryStrategyFactory, properties);
         joinConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(discoveryStrategyConfig);
         
@@ -215,7 +215,7 @@ Following are example declarative and programmatic configuration snippets:
         properties.put("security-group-name","hazelcast");
         properties.put("tag-key","aws-test-cluster");
         properties.put("tag-value","cluster1");
-        properties.put("hzPort","5701");
+        properties.put("hz-port","5701");
         AwsDiscoveryStrategyFactory awsDiscoveryStrategyFactory = new AwsDiscoveryStrategyFactory();
         DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(awsDiscoveryStrategyFactory, properties);
         ClientNetworkConfig clientNetworkConfig = clientConfig.getNetworkConfig();

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ If more than one `subnet` or `custom VPC` is used for cluster, it should be chec
 - Add the *hazelcast-aws.jar* dependency to your project. The hazelcast-aws plugin does not depend on any other third party modules.
 - Enable Discovery SPI by adding "hazelcast.discovery.enabled" property to your config.
 - Enable public/private IP address translation using "hazelcast.discovery.public.ip.enabled" if your Hazelcast Client is not in AWS.
+- Make sure `access-key` and `secret-key` properties are set in case your client is outside AWS (`iam-role` works only for clients inside AWS)
 
 Following are example declarative and programmatic configuration snippets:
 

--- a/src/main/java/com/hazelcast/aws/utility/MetadataUtil.java
+++ b/src/main/java/com/hazelcast/aws/utility/MetadataUtil.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 public final class MetadataUtil {
 
     /**
-     * This IP is only accessible within an EC2 instance and is used to fetch metadata of running instance
+     * This IP is only accessible inside AWS and is used to fetch metadata of running EC2 Instance
      * See details at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
      */
     public static final String INSTANCE_METADATA_URI = "http://169.254.169.254/latest/meta-data/";

--- a/src/main/java/com/hazelcast/aws/utility/MetadataUtil.java
+++ b/src/main/java/com/hazelcast/aws/utility/MetadataUtil.java
@@ -30,8 +30,9 @@ import java.util.concurrent.TimeUnit;
 public final class MetadataUtil {
 
     /**
-     * This IP is only accessible inside AWS and is used to fetch metadata of running EC2 Instance
-     * See details at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+     * This IP is only accessible inside AWS and is used to fetch metadata of running EC2 Instance.
+     * Outside connection is only possible with the keys.
+     * See details at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html.
      */
     public static final String INSTANCE_METADATA_URI = "http://169.254.169.254/latest/meta-data/";
 


### PR DESCRIPTION
- Add info about iam-role and client outside AWS
- Fix typo "hzPort" => "hz-port"

Related to: https://github.com/hazelcast/hazelcast-aws/issues/59