### PR TITLE
Issue 64

### DIFF
--- a/src/main/java/com/hazelcast/aws/AWSClient.java
+++ b/src/main/java/com/hazelcast/aws/AWSClient.java
@@ -17,7 +17,6 @@
 package com.hazelcast.aws;
 
 import com.hazelcast.aws.impl.DescribeInstances;
-import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 
 import java.util.Collection;

--- a/src/main/java/com/hazelcast/aws/AWSClient.java
+++ b/src/main/java/com/hazelcast/aws/AWSClient.java
@@ -57,7 +57,7 @@ public class AWSClient {
 
     public String getAvailabilityZone() {
         String uri = INSTANCE_METADATA_URI.concat(AVAILABILITY_ZONE_URI);
-        return retrieveMetadataFromURI(uri, awsConfig.getConnectionTimeoutSeconds());
+        return retrieveMetadataFromURI(uri, awsConfig.getConnectionTimeoutSeconds(), awsConfig.getConnectionRetries());
     }
 
     public void setEndpoint(String s) {

--- a/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -1,270 +1,192 @@
 package com.hazelcast.aws;
 
-import com.hazelcast.config.TcpIpConfig;
-
-import static com.hazelcast.util.Preconditions.checkHasText;
-
+/**
+ * AWS Discovery Strategy configuration that corresponds to the properties passed in the Hazelcast configuration and listed in
+ * {@link AwsProperties}.
+ */
 public class AwsConfig {
-
-    private static final int CONNECTION_TIMEOUT = 5;
-
-    private boolean enabled;
     private String accessKey;
     private String secretKey;
-    private String region = "us-east-1";
-    private String securityGroupName;
-    private String tagKey;
-    private String tagValue;
-    private String hostHeader = "ec2.amazonaws.com";
+    private final String region;
     private String iamRole;
-    private int connectionTimeoutSeconds = CONNECTION_TIMEOUT;
-    private int connectionRetries;
+    private final String hostHeader;
+    private final String securityGroupName;
+    private final String tagKey;
+    private final String tagValue;
+    private final int connectionTimeoutSeconds;
+    private final int connectionRetries;
+    private final PortRange hzPort;
 
-    /**
-     * Gets the access key to access AWS. Returns null if no access key is configured.
-     *
-     * @return the access key to access AWS
-     * @see #setAccessKey(String)
-     */
+    private AwsConfig(String accessKey, String secretKey, String region, String iamRole, String hostHeader,
+                      String securityGroupName, String tagKey, String tagValue, int connectionTimeoutSeconds,
+                      int connectionRetries, PortRange hzPort) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.region = region;
+        this.iamRole = iamRole;
+        this.hostHeader = hostHeader;
+        this.securityGroupName = securityGroupName;
+        this.tagKey = tagKey;
+        this.tagValue = tagValue;
+        this.connectionTimeoutSeconds = connectionTimeoutSeconds;
+        this.connectionRetries = connectionRetries;
+        this.hzPort = hzPort;
+    }
+
+    public static class Builder {
+        private String accessKey;
+        private String secretKey;
+        private String region;
+        private String iamRole;
+        private String hostHeader;
+        private String securityGroupName;
+        private String tagKey;
+        private String tagValue;
+        private int connectionTimeoutSeconds;
+        private int connectionRetries;
+        private PortRange hzPort;
+
+        public Builder setAccessKey(String accessKey) {
+            this.accessKey = accessKey;
+            return this;
+        }
+
+        public Builder setSecretKey(String secretKey) {
+            this.secretKey = secretKey;
+            return this;
+        }
+
+        public Builder setRegion(String region) {
+            this.region = region;
+            return this;
+        }
+
+        public Builder setIamRole(String iamRole) {
+            this.iamRole = iamRole;
+            return this;
+        }
+
+        public Builder setHostHeader(String hostHeader) {
+            this.hostHeader = hostHeader;
+            return this;
+        }
+
+        public Builder setSecurityGroupName(String securityGroupName) {
+            this.securityGroupName = securityGroupName;
+            return this;
+        }
+
+        public Builder setTagKey(String tagKey) {
+            this.tagKey = tagKey;
+            return this;
+        }
+
+        public Builder setTagValue(String tagValue) {
+            this.tagValue = tagValue;
+            return this;
+        }
+
+        public Builder setConnectionTimeoutSeconds(int connectionTimeoutSeconds) {
+            this.connectionTimeoutSeconds = connectionTimeoutSeconds;
+            return this;
+        }
+
+        public Builder setConnectionRetries(int connectionRetries) {
+            this.connectionRetries = connectionRetries;
+            return this;
+        }
+
+        public Builder setHzPort(PortRange hzPort) {
+            this.hzPort = hzPort;
+            return this;
+        }
+
+        public AwsConfig build() {
+            return new AwsConfig(accessKey, secretKey, region, iamRole, hostHeader, securityGroupName, tagKey, tagValue,
+                    connectionTimeoutSeconds, connectionRetries, hzPort);
+        }
+    }
+
     public String getAccessKey() {
         return accessKey;
     }
 
-    /**
-     * Sets the access key to access AWS.
-     *
-     * @param accessKey the access key to access AWS
-     * @return the updated AwsConfig.
-     * @throws IllegalArgumentException if accessKey is null or empty.
-     * @see #getAccessKey()
-     * @see #setSecretKey(String)
-     */
-    public AwsConfig setAccessKey(String accessKey) {
-        this.accessKey = checkHasText(accessKey, "accessKey must contain text");
-        return this;
-    }
-
-    /**
-     * Gets the secret key to access AWS. Returns null if no access key is configured.
-     *
-     * @return the secret key.
-     * @see #setSecretKey(String)
-     */
     public String getSecretKey() {
         return secretKey;
     }
 
-    /**
-     * Sets the secret key to access AWS.
-     *
-     * @param secretKey the secret key to access AWS
-     * @return the updated AwsConfig.
-     * @throws IllegalArgumentException if secretKey is null or empty.
-     * @see #getSecretKey()
-     * @see #setAccessKey(String)
-     */
-    public AwsConfig setSecretKey(String secretKey) {
-        this.secretKey = checkHasText(secretKey, "secretKey must contain text");
-        return this;
-    }
-
-    /**
-     * Gets the region where the EC2 instances running the Hazelcast members will be running.
-     *
-     * @return the region where the EC2 instances running the Hazelcast members will be running
-     * @see #setRegion(String)
-     */
     public String getRegion() {
         return region;
     }
 
-    /**
-     * Sets the region where the EC2 instances running the Hazelcast members will be running.
-     *
-     * @param region the region where the EC2 instances running the Hazelcast members will be running
-     * @return the updated AwsConfig
-     * @throws IllegalArgumentException if region is null or empty.
-     */
-    public AwsConfig setRegion(String region) {
-        this.region = checkHasText(region, "region must contain text");
-        return this;
+    public String getIamRole() {
+        return iamRole;
     }
 
-    /**
-     * Gets the host header; the address where the EC2 API can be found.
-     *
-     * @return the host header; the address where the EC2 API can be found
-     */
     public String getHostHeader() {
         return hostHeader;
     }
 
-    /**
-     * Sets the host header; the address where the EC2 API can be found.
-     *
-     * @param hostHeader the new host header; the address where the EC2 API can be found
-     * @return the updated AwsConfig
-     * @throws IllegalArgumentException if hostHeader is null or an empty string.
-     */
-    public AwsConfig setHostHeader(String hostHeader) {
-        this.hostHeader = checkHasText(hostHeader, "hostHeader must contain text");
-        return this;
-    }
-
-    /**
-     * Enables or disables the aws join mechanism.
-     *
-     * @param enabled true if enabled, false otherwise.
-     * @return the updated AwsConfig.
-     */
-    public AwsConfig setEnabled(boolean enabled) {
-        this.enabled = enabled;
-        return this;
-    }
-
-    /**
-     * Checks if the aws join mechanism is enabled.
-     *
-     * @return true if enabled, false otherwise.
-     */
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    /**
-     * Sets the security group name. See the filtering section above for more information.
-     *
-     * @param securityGroupName the security group name.
-     * @return the updated AwsConfig.
-     * @see #getSecurityGroupName()
-     */
-    public AwsConfig setSecurityGroupName(String securityGroupName) {
-        this.securityGroupName = securityGroupName;
-        return this;
-    }
-
-    /**
-     * Gets the security group name. If nothing has been configured, null is returned.
-     *
-     * @return the security group name; null if nothing has been configured
-     */
     public String getSecurityGroupName() {
         return securityGroupName;
     }
 
-    /**
-     * Sets the tag key. See the filtering section above for more information.
-     *
-     * @param tagKey the tag key. See the filtering section above for more information.
-     * @return the updated AwsConfig.
-     * @see #setTagKey(String)
-     */
-    public AwsConfig setTagKey(String tagKey) {
-        this.tagKey = tagKey;
-        return this;
-    }
-
-    /**
-     * Sets the tag value. See the filtering section above for more information.
-     *
-     * @param tagValue the tag value. See the filtering section above for more information.
-     * @return the updated AwsConfig.
-     * @see #setTagKey(String)
-     * @see #getTagValue()
-     */
-    public AwsConfig setTagValue(String tagValue) {
-        this.tagValue = tagValue;
-        return this;
-    }
-
-    /**
-     * Gets the tag key. If nothing is specified, null is returned.
-     *
-     * @return the tag key. null if nothing is returned.
-     */
     public String getTagKey() {
         return tagKey;
     }
 
-    /**
-     * Gets the tag value. If nothing is specified, null is returned.
-     *
-     * @return the tag value. null if nothing is returned.
-     */
     public String getTagValue() {
         return tagValue;
     }
 
-    /**
-     * Gets the connection timeout in seconds.
-     *
-     * @return the connectionTimeoutSeconds; connection timeout in seconds
-     * @see #setConnectionTimeoutSeconds(int)
-     */
     public int getConnectionTimeoutSeconds() {
         return connectionTimeoutSeconds;
-    }
-
-    /**
-     * Sets the connect timeout in seconds. See {@link TcpIpConfig#setConnectionTimeoutSeconds(int)} for more information.
-     *
-     * @param connectionTimeoutSeconds the connectionTimeoutSeconds (connection timeout in seconds) to set
-     * @return the updated AwsConfig.
-     * @see #getConnectionTimeoutSeconds()
-     * @see TcpIpConfig#setConnectionTimeoutSeconds(int)
-     */
-    public AwsConfig setConnectionTimeoutSeconds(final int connectionTimeoutSeconds) {
-        if (connectionTimeoutSeconds < 0) {
-            throw new IllegalArgumentException("connection timeout can't be smaller than 0");
-        }
-        this.connectionTimeoutSeconds = connectionTimeoutSeconds;
-        return this;
     }
 
     public int getConnectionRetries() {
         return connectionRetries;
     }
 
-    public AwsConfig setConnectionRetries(final int connectionRetries) {
-        if (connectionTimeoutSeconds < 1) {
-            throw new IllegalArgumentException("connection retries can't be smaller than 1");
-        }
-        this.connectionRetries = connectionRetries;
-        return this;
+    public PortRange getHzPort() {
+        return hzPort;
     }
 
-    /**
-     * Gets the iamRole name
+    /** Sets {@code accessKey}.
      *
-     * @return the iamRole. null if nothing is returned.
-     * @see #setIamRole(String) (int)
+     * @deprecated It violates the immutability of {@link AwsConfig}.
      */
-    public String getIamRole() {
-        return iamRole;
+    @Deprecated
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
     }
 
-    /**
-     * Sets the tag value. See the filtering section above for more information.
+    /** Sets {@code secretKey}.
      *
-     * @param iamRole the IAM Role name.
-     * @return the updated AwsConfig.
-     * @see #getIamRole()
+     * @deprecated It violates the immutability of {@link AwsConfig}.
      */
-    public AwsConfig setIamRole(String iamRole) {
+    @Deprecated
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    /** Sets {@code iamRole}.
+     *
+     * @deprecated It violates the immutability of {@link AwsConfig}.
+     */
+    @Deprecated
+    public void setIamRole(String iamRole) {
         this.iamRole = iamRole;
-        return this;
     }
 
     @Override
     public String toString() {
-        return "AwsConfig{"
-                + "enabled=" + enabled
-                + ", region='" + region + '\''
-                + ", securityGroupName='" + securityGroupName + '\''
-                + ", tagKey='" + tagKey + '\''
-                + ", tagValue='" + tagValue + '\''
-                + ", hostHeader='" + hostHeader + '\''
-                + ", iamRole='" + iamRole + '\''
-                + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds + '}';
+        return "AwsConfig{" + "accessKey='***', secretKey='***', region='" + region + '\'' + ", iamRole='" + iamRole + '\''
+                + ", hostHeader='" + hostHeader + '\'' + ", securityGroupName='" + securityGroupName + '\'' + ", tagKey='"
+                + tagKey + '\'' + ", tagValue='" + tagValue + '\'' + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds
+                + ", connectionRetries=" + connectionRetries + ", hzPort=" + hzPort + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 }

--- a/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.aws;
 
 /**
  * AWS Discovery Strategy configuration that corresponds to the properties passed in the Hazelcast configuration and listed in
  * {@link AwsProperties}.
  */
-public class AwsConfig {
+public final class AwsConfig {
     private String accessKey;
     private String secretKey;
     private final String region;
@@ -17,6 +33,8 @@ public class AwsConfig {
     private final int connectionRetries;
     private final PortRange hzPort;
 
+    @SuppressWarnings("checkstyle:parameternumber")
+    // Constructor has a lot of parameters, but it's private.
     private AwsConfig(String accessKey, String secretKey, String region, String iamRole, String hostHeader,
                       String securityGroupName, String tagKey, String tagValue, int connectionTimeoutSeconds,
                       int connectionRetries, PortRange hzPort) {

--- a/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -1,0 +1,270 @@
+package com.hazelcast.aws;
+
+import com.hazelcast.config.TcpIpConfig;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+
+public class AwsConfig {
+
+    private static final int CONNECTION_TIMEOUT = 5;
+
+    private boolean enabled;
+    private String accessKey;
+    private String secretKey;
+    private String region = "us-east-1";
+    private String securityGroupName;
+    private String tagKey;
+    private String tagValue;
+    private String hostHeader = "ec2.amazonaws.com";
+    private String iamRole;
+    private int connectionTimeoutSeconds = CONNECTION_TIMEOUT;
+    private int connectionRetries;
+
+    /**
+     * Gets the access key to access AWS. Returns null if no access key is configured.
+     *
+     * @return the access key to access AWS
+     * @see #setAccessKey(String)
+     */
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    /**
+     * Sets the access key to access AWS.
+     *
+     * @param accessKey the access key to access AWS
+     * @return the updated AwsConfig.
+     * @throws IllegalArgumentException if accessKey is null or empty.
+     * @see #getAccessKey()
+     * @see #setSecretKey(String)
+     */
+    public AwsConfig setAccessKey(String accessKey) {
+        this.accessKey = checkHasText(accessKey, "accessKey must contain text");
+        return this;
+    }
+
+    /**
+     * Gets the secret key to access AWS. Returns null if no access key is configured.
+     *
+     * @return the secret key.
+     * @see #setSecretKey(String)
+     */
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    /**
+     * Sets the secret key to access AWS.
+     *
+     * @param secretKey the secret key to access AWS
+     * @return the updated AwsConfig.
+     * @throws IllegalArgumentException if secretKey is null or empty.
+     * @see #getSecretKey()
+     * @see #setAccessKey(String)
+     */
+    public AwsConfig setSecretKey(String secretKey) {
+        this.secretKey = checkHasText(secretKey, "secretKey must contain text");
+        return this;
+    }
+
+    /**
+     * Gets the region where the EC2 instances running the Hazelcast members will be running.
+     *
+     * @return the region where the EC2 instances running the Hazelcast members will be running
+     * @see #setRegion(String)
+     */
+    public String getRegion() {
+        return region;
+    }
+
+    /**
+     * Sets the region where the EC2 instances running the Hazelcast members will be running.
+     *
+     * @param region the region where the EC2 instances running the Hazelcast members will be running
+     * @return the updated AwsConfig
+     * @throws IllegalArgumentException if region is null or empty.
+     */
+    public AwsConfig setRegion(String region) {
+        this.region = checkHasText(region, "region must contain text");
+        return this;
+    }
+
+    /**
+     * Gets the host header; the address where the EC2 API can be found.
+     *
+     * @return the host header; the address where the EC2 API can be found
+     */
+    public String getHostHeader() {
+        return hostHeader;
+    }
+
+    /**
+     * Sets the host header; the address where the EC2 API can be found.
+     *
+     * @param hostHeader the new host header; the address where the EC2 API can be found
+     * @return the updated AwsConfig
+     * @throws IllegalArgumentException if hostHeader is null or an empty string.
+     */
+    public AwsConfig setHostHeader(String hostHeader) {
+        this.hostHeader = checkHasText(hostHeader, "hostHeader must contain text");
+        return this;
+    }
+
+    /**
+     * Enables or disables the aws join mechanism.
+     *
+     * @param enabled true if enabled, false otherwise.
+     * @return the updated AwsConfig.
+     */
+    public AwsConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Checks if the aws join mechanism is enabled.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets the security group name. See the filtering section above for more information.
+     *
+     * @param securityGroupName the security group name.
+     * @return the updated AwsConfig.
+     * @see #getSecurityGroupName()
+     */
+    public AwsConfig setSecurityGroupName(String securityGroupName) {
+        this.securityGroupName = securityGroupName;
+        return this;
+    }
+
+    /**
+     * Gets the security group name. If nothing has been configured, null is returned.
+     *
+     * @return the security group name; null if nothing has been configured
+     */
+    public String getSecurityGroupName() {
+        return securityGroupName;
+    }
+
+    /**
+     * Sets the tag key. See the filtering section above for more information.
+     *
+     * @param tagKey the tag key. See the filtering section above for more information.
+     * @return the updated AwsConfig.
+     * @see #setTagKey(String)
+     */
+    public AwsConfig setTagKey(String tagKey) {
+        this.tagKey = tagKey;
+        return this;
+    }
+
+    /**
+     * Sets the tag value. See the filtering section above for more information.
+     *
+     * @param tagValue the tag value. See the filtering section above for more information.
+     * @return the updated AwsConfig.
+     * @see #setTagKey(String)
+     * @see #getTagValue()
+     */
+    public AwsConfig setTagValue(String tagValue) {
+        this.tagValue = tagValue;
+        return this;
+    }
+
+    /**
+     * Gets the tag key. If nothing is specified, null is returned.
+     *
+     * @return the tag key. null if nothing is returned.
+     */
+    public String getTagKey() {
+        return tagKey;
+    }
+
+    /**
+     * Gets the tag value. If nothing is specified, null is returned.
+     *
+     * @return the tag value. null if nothing is returned.
+     */
+    public String getTagValue() {
+        return tagValue;
+    }
+
+    /**
+     * Gets the connection timeout in seconds.
+     *
+     * @return the connectionTimeoutSeconds; connection timeout in seconds
+     * @see #setConnectionTimeoutSeconds(int)
+     */
+    public int getConnectionTimeoutSeconds() {
+        return connectionTimeoutSeconds;
+    }
+
+    /**
+     * Sets the connect timeout in seconds. See {@link TcpIpConfig#setConnectionTimeoutSeconds(int)} for more information.
+     *
+     * @param connectionTimeoutSeconds the connectionTimeoutSeconds (connection timeout in seconds) to set
+     * @return the updated AwsConfig.
+     * @see #getConnectionTimeoutSeconds()
+     * @see TcpIpConfig#setConnectionTimeoutSeconds(int)
+     */
+    public AwsConfig setConnectionTimeoutSeconds(final int connectionTimeoutSeconds) {
+        if (connectionTimeoutSeconds < 0) {
+            throw new IllegalArgumentException("connection timeout can't be smaller than 0");
+        }
+        this.connectionTimeoutSeconds = connectionTimeoutSeconds;
+        return this;
+    }
+
+    public int getConnectionRetries() {
+        return connectionRetries;
+    }
+
+    public AwsConfig setConnectionRetries(final int connectionRetries) {
+        if (connectionTimeoutSeconds < 1) {
+            throw new IllegalArgumentException("connection retries can't be smaller than 1");
+        }
+        this.connectionRetries = connectionRetries;
+        return this;
+    }
+
+    /**
+     * Gets the iamRole name
+     *
+     * @return the iamRole. null if nothing is returned.
+     * @see #setIamRole(String) (int)
+     */
+    public String getIamRole() {
+        return iamRole;
+    }
+
+    /**
+     * Sets the tag value. See the filtering section above for more information.
+     *
+     * @param iamRole the IAM Role name.
+     * @return the updated AwsConfig.
+     * @see #getIamRole()
+     */
+    public AwsConfig setIamRole(String iamRole) {
+        this.iamRole = iamRole;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "AwsConfig{"
+                + "enabled=" + enabled
+                + ", region='" + region + '\''
+                + ", securityGroupName='" + securityGroupName + '\''
+                + ", tagKey='" + tagKey + '\''
+                + ", tagValue='" + tagValue + '\''
+                + ", hostHeader='" + hostHeader + '\''
+                + ", iamRole='" + iamRole + '\''
+                + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds + '}';
+    }
+}

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -56,9 +56,9 @@ public class AwsDiscoveryStrategy
     private static final ILogger LOGGER = Logger.getLogger(AwsDiscoveryStrategy.class);
     private static final String DEFAULT_PORT_RANGE = "5701-5708";
     private static final Integer DEFAULT_CONNECTION_RETRIES = 10;
-    public static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10;
-    public static final String DEFAULT_REGION = "us-east-1";
-    public static final String DEFAULT_HOST_HEADER = "ec2.amazonaws.com";
+    private static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10;
+    private static final String DEFAULT_REGION = "us-east-1";
+    private static final String DEFAULT_HOST_HEADER = "ec2.amazonaws.com";
 
     private final AwsConfig awsConfig;
     private final AWSClient awsClient;

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -56,17 +56,20 @@ public class AwsDiscoveryStrategy
     private static final ILogger LOGGER = Logger.getLogger(AwsDiscoveryStrategy.class);
     private static final String DEFAULT_PORT_RANGE = "5701-5708";
     private static final Integer DEFAULT_CONNECTION_RETRIES = 10;
+    public static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10;
+    public static final String DEFAULT_REGION = "us-east-1";
+    public static final String DEFAULT_HOST_HEADER = "ec2.amazonaws.com";
 
+    private final AwsConfig awsConfig;
     private final AWSClient awsClient;
-    private final PortRange portRange;
 
     private final Map<String, Object> memberMetadata = new HashMap<String, Object>();
 
     public AwsDiscoveryStrategy(Map<String, Comparable> properties) {
         super(LOGGER, properties);
-        this.portRange = new PortRange(getPortRange());
+        this.awsConfig = getAwsConfig();
         try {
-            this.awsClient = new AWSClient(getAwsConfig());
+            this.awsClient = new AWSClient(awsConfig);
         } catch (IllegalArgumentException e) {
             throw new InvalidConfigurationException("AWS configuration is not valid", e);
         }
@@ -77,8 +80,29 @@ public class AwsDiscoveryStrategy
      */
     AwsDiscoveryStrategy(Map<String, Comparable> properties, AWSClient client) {
         super(LOGGER, properties);
-        this.portRange = new PortRange(getPortRange());
+        this.awsConfig = getAwsConfig();
         this.awsClient = client;
+    }
+
+    private AwsConfig getAwsConfig()
+            throws IllegalArgumentException {
+        final AwsConfig config = AwsConfig.builder()
+                .setAccessKey(getOrNull(ACCESS_KEY))
+                .setSecretKey(getOrNull(SECRET_KEY))
+                .setRegion(getOrDefault(REGION.getDefinition(), DEFAULT_REGION))
+                .setIamRole(getOrNull(IAM_ROLE))
+                .setHostHeader(getOrDefault(HOST_HEADER.getDefinition(), DEFAULT_HOST_HEADER))
+                .setSecurityGroupName(getOrNull(SECURITY_GROUP_NAME))
+                .setTagKey(getOrNull(TAG_KEY))
+                .setTagValue(getOrNull(TAG_VALUE))
+                .setConnectionTimeoutSeconds(
+                        getOrDefault(CONNECTION_TIMEOUT_SECONDS.getDefinition(), DEFAULT_CONNECTION_TIMEOUT_SECONDS))
+                .setConnectionRetries(getOrDefault(CONNECTION_RETRIES.getDefinition(), DEFAULT_CONNECTION_RETRIES))
+                .setHzPort(new PortRange(getPortRange()))
+                .build();
+
+        reviewConfiguration(config);
+        return config;
     }
 
     /**
@@ -95,45 +119,9 @@ public class AwsDiscoveryStrategy
         return portRange.toString();
     }
 
-    private AwsConfig getAwsConfig()
-            throws IllegalArgumentException {
-        final AwsConfig config = new AwsConfig().setEnabled(true).setSecurityGroupName(getOrNull(SECURITY_GROUP_NAME))
-                                                .setTagKey(getOrNull(TAG_KEY)).setTagValue(getOrNull(TAG_VALUE))
-                                                .setIamRole(getOrNull(IAM_ROLE));
-
-        String property = getOrNull(ACCESS_KEY);
-        if (property != null) {
-            config.setAccessKey(property);
-        }
-
-        property = getOrNull(SECRET_KEY);
-        if (property != null) {
-            config.setSecretKey(property);
-        }
-
-        final Integer timeout = getOrDefault(CONNECTION_TIMEOUT_SECONDS.getDefinition(), 10);
-        config.setConnectionTimeoutSeconds(timeout);
-
-        final Integer connectionRetries = getOrDefault(CONNECTION_RETRIES.getDefinition(), DEFAULT_CONNECTION_RETRIES);
-        config.setConnectionRetries(connectionRetries);
-
-        final String region = getOrNull(REGION);
-        if (region != null) {
-            config.setRegion(region);
-        }
-
-        final String hostHeader = getOrNull(HOST_HEADER);
-        if (hostHeader != null) {
-            config.setHostHeader(hostHeader);
-        }
-
-        reviewConfiguration(config);
-        return config;
-    }
-
     private void reviewConfiguration(AwsConfig config) {
-        if (StringUtil.isNullOrEmptyAfterTrim(config.getSecretKey()) || StringUtil
-                .isNullOrEmptyAfterTrim(config.getAccessKey())) {
+        if (StringUtil.isNullOrEmptyAfterTrim(config.getSecretKey()) || StringUtil.isNullOrEmptyAfterTrim(
+                config.getAccessKey())) {
 
             if (!StringUtil.isNullOrEmptyAfterTrim(config.getIamRole())) {
                 getLogger().info("Describe instances will be queried with iam-role, "
@@ -176,7 +164,9 @@ public class AwsDiscoveryStrategy
 
             final ArrayList<DiscoveryNode> nodes = new ArrayList<DiscoveryNode>(privatePublicIpAddressPairs.size());
             for (Map.Entry<String, String> entry : privatePublicIpAddressPairs.entrySet()) {
-                for (int port = portRange.getFromPort(); port <= portRange.getToPort(); port++) {
+                for (int port = awsConfig.getHzPort()
+                        .getFromPort(); port <= awsConfig.getHzPort()
+                        .getToPort(); port++) {
                     nodes.add(new SimpleDiscoveryNode(new Address(entry.getKey(), port), new Address(entry.getValue(), port)));
                 }
             }

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -173,7 +173,8 @@ public class AwsDiscoveryStrategy
 
             return nodes;
         } catch (Exception e) {
-            throw rethrow(e);
+            LOGGER.warning("Cannot discover nodes, returning empty list", e);
+            return Collections.emptyList();
         }
     }
 

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -44,7 +44,6 @@ import static com.hazelcast.aws.AwsProperties.SECRET_KEY;
 import static com.hazelcast.aws.AwsProperties.SECURITY_GROUP_NAME;
 import static com.hazelcast.aws.AwsProperties.TAG_KEY;
 import static com.hazelcast.aws.AwsProperties.TAG_VALUE;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
  * AWS implementation of {@link DiscoveryStrategy}.

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.aws;
 
-import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.logging.ILogger;
@@ -35,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.hazelcast.aws.AwsProperties.ACCESS_KEY;
+import static com.hazelcast.aws.AwsProperties.CONNECTION_RETRIES;
 import static com.hazelcast.aws.AwsProperties.CONNECTION_TIMEOUT_SECONDS;
 import static com.hazelcast.aws.AwsProperties.HOST_HEADER;
 import static com.hazelcast.aws.AwsProperties.IAM_ROLE;
@@ -55,6 +55,7 @@ public class AwsDiscoveryStrategy
         extends AbstractDiscoveryStrategy {
     private static final ILogger LOGGER = Logger.getLogger(AwsDiscoveryStrategy.class);
     private static final String DEFAULT_PORT_RANGE = "5701-5708";
+    private static final Integer DEFAULT_CONNECTION_RETRIES = 10;
 
     private final AWSClient awsClient;
     private final PortRange portRange;
@@ -112,6 +113,9 @@ public class AwsDiscoveryStrategy
 
         final Integer timeout = getOrDefault(CONNECTION_TIMEOUT_SECONDS.getDefinition(), 10);
         config.setConnectionTimeoutSeconds(timeout);
+
+        final Integer connectionRetries = getOrDefault(CONNECTION_RETRIES.getDefinition(), DEFAULT_CONNECTION_RETRIES);
+        config.setConnectionRetries(connectionRetries);
 
         final String region = getOrNull(REGION);
         if (region != null) {

--- a/src/main/java/com/hazelcast/aws/AwsProperties.java
+++ b/src/main/java/com/hazelcast/aws/AwsProperties.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.aws;
 
-import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.PropertyTypeConverter;
@@ -81,6 +80,11 @@ public enum AwsProperties {
      * Its default value is 5.
      */
     CONNECTION_TIMEOUT_SECONDS("connection-timeout-seconds", INTEGER, true),
+
+    /**
+     * Number of retries while connecting to AWS Services. Its default value is 10.
+     */
+    CONNECTION_RETRIES("connection-retries", INTEGER, true),
 
     /**
      * The discovery mechanism will discover only IP addresses. You can define the port or the port range on which Hazelcast is

--- a/src/main/java/com/hazelcast/aws/AwsProperties.java
+++ b/src/main/java/com/hazelcast/aws/AwsProperties.java
@@ -83,6 +83,8 @@ public enum AwsProperties {
 
     /**
      * Number of retries while connecting to AWS Services. Its default value is 10.
+     * <p>
+     * Hazelcast AWS plugin uses two AWS services: Describe Instances and EC2 Instance Metadata.
      */
     CONNECTION_RETRIES("connection-retries", INTEGER, true),
 

--- a/src/main/java/com/hazelcast/aws/AwsProperties.java
+++ b/src/main/java/com/hazelcast/aws/AwsProperties.java
@@ -27,7 +27,7 @@ import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
 /**
  * Configuration properties for the Hazelcast Discovery Plugin for AWS. For more information
- * see {@link AwsConfig}
+ * see {@link AwsConfig}.
  */
 public enum AwsProperties {
 

--- a/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
+++ b/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
@@ -25,8 +25,6 @@ import com.hazelcast.aws.utility.MetadataUtil;
 import com.hazelcast.aws.utility.RetryUtils;
 import com.hazelcast.com.eclipsesource.json.JsonObject;
 import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -57,8 +55,6 @@ import static com.hazelcast.nio.IOUtil.closeResource;
  * for AWS API details.
  */
 public class DescribeInstances {
-    private static final ILogger logger = Logger.getLogger(DescribeInstances.class);
-
     /**
      * URI to fetch container credentials (when IAM role is enabled)
      *

--- a/src/main/java/com/hazelcast/aws/security/EC2RequestSigner.java
+++ b/src/main/java/com/hazelcast/aws/security/EC2RequestSigner.java
@@ -18,7 +18,7 @@ package com.hazelcast.aws.security;
 
 import com.hazelcast.aws.impl.Constants;
 import com.hazelcast.aws.utility.AwsURLEncoder;
-import com.hazelcast.config.AwsConfig;
+import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.util.QuickMath;
 
 import javax.crypto.Mac;

--- a/src/main/java/com/hazelcast/aws/utility/MetadataUtil.java
+++ b/src/main/java/com/hazelcast/aws/utility/MetadataUtil.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 public final class MetadataUtil {
@@ -52,9 +53,10 @@ public final class MetadataUtil {
     }
 
     /**
-     * This is a helper method that simply performs the HTTP request to retrieve metadata, from a given URI.
-     * (It allows us to cleanly separate the network calls out of our main code logic, so we can mock in our UT.)
-     * @param uri the full URI where a `GET` request will retrieve the metadata information, represented as JSON.
+     * Performs the HTTP request to retrieve AWS Instance Metadata from the given URI.
+     *
+     * @param uri              the full URI where a `GET` request will retrieve the metadata information, represented as JSON.
+     * @param timeoutInSeconds timeout for the AWS service call
      * @return The content of the HTTP response, as a String. NOTE: This is NEVER null.
      */
     public static String retrieveMetadataFromURI(String uri, int timeoutInSeconds) {
@@ -92,4 +94,20 @@ public final class MetadataUtil {
         }
     }
 
+    /**
+     * Performs the HTTP request to retrieve AWS Instance Metadata from the given URI.
+     *
+     * @param uri              the full URI where a `GET` request will retrieve the metadata information, represented as JSON.
+     * @param timeoutInSeconds timeout for the AWS service call
+     * @param retries          number of retries in case the AWS request fails
+     * @return The content of the HTTP response, as a String. NOTE: This is NEVER null.
+     */
+    public static String retrieveMetadataFromURI(final String uri, final int timeoutInSeconds, int retries) {
+        return RetryUtils.retry(new Callable<String>() {
+            @Override
+            public String call() {
+                return retrieveMetadataFromURI(uri, timeoutInSeconds);
+            }
+        }, retries);
+    }
 }

--- a/src/main/java/com/hazelcast/aws/utility/RetryUtils.java
+++ b/src/main/java/com/hazelcast/aws/utility/RetryUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.aws.utility;
 
 import com.hazelcast.core.HazelcastException;
@@ -10,8 +26,11 @@ import java.util.concurrent.Callable;
 /**
  * Static utility class to retry operations related to connecting to AWS Services.
  */
-public class RetryUtils {
-    private static final ILogger logger = Logger.getLogger(RetryUtils.class);
+public final class RetryUtils {
+    private static final ILogger LOGGER = Logger.getLogger(RetryUtils.class);
+
+    private RetryUtils() {
+    }
 
     /**
      * Calls {@code callable.call()} until it does not throw an exception (but no more than {@code retries} times).
@@ -30,7 +49,7 @@ public class RetryUtils {
                 if (retryCount > retries) {
                     throw ExceptionUtil.rethrow(e);
                 }
-                logger.warning(String.format("Couldn't connect to the AWS service, %s retrying...", retryCount));
+                LOGGER.warning(String.format("Couldn't connect to the AWS service, %s retrying...", retryCount));
             }
         }
     }

--- a/src/main/java/com/hazelcast/aws/utility/RetryUtils.java
+++ b/src/main/java/com/hazelcast/aws/utility/RetryUtils.java
@@ -1,0 +1,37 @@
+package com.hazelcast.aws.utility;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Static utility class to retry operations related to connecting to AWS Services.
+ */
+public class RetryUtils {
+    private static final ILogger logger = Logger.getLogger(RetryUtils.class);
+
+    /**
+     * Calls {@code callable.call()} until it does not throw an exception (but no more than {@code retries} times).
+     * <p>
+     * Note that {@code callable} should be an idempotent operation which is a call to the AWS Service.
+     * <p>
+     * If {@code callable} throws an unchecked exception, it is wrapped into {@link HazelcastException}.
+     */
+    public static <T> T retry(Callable<T> callable, int retries) {
+        int retryCount = 0;
+        while (true) {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                retryCount++;
+                if (retryCount > retries) {
+                    throw ExceptionUtil.rethrow(e);
+                }
+                logger.warning(String.format("Couldn't connect to the AWS service, %s retrying...", retryCount));
+            }
+        }
+    }
+}

--- a/src/main/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWS.java
+++ b/src/main/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWS.java
@@ -17,13 +17,19 @@
 package com.hazelcast.cluster.impl;
 
 import com.hazelcast.aws.AWSClient;
-import com.hazelcast.config.AwsConfig;
+import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collection;
 
+/**
+ * Joiner used for the deprecated AwsConfig.
+ *
+ * @deprecated Use {@link AwsDiscoveryStrategy} instead of AwsConfig.
+ */
+@Deprecated
 public class TcpIpJoinerOverAWS extends TcpIpJoiner {
 
     private final AWSClient aws;
@@ -33,7 +39,7 @@ public class TcpIpJoinerOverAWS extends TcpIpJoiner {
         super(node);
         logger = node.getLogger(getClass());
 
-        AwsConfig awsConfig = node.getConfig().getNetworkConfig().getJoin().getAwsConfig();
+        AwsConfig awsConfig = fromDeprecatedAwsConfig(node.getConfig().getNetworkConfig().getJoin().getAwsConfig());
         aws = new AWSClient(awsConfig);
     }
 
@@ -61,12 +67,27 @@ public class TcpIpJoinerOverAWS extends TcpIpJoiner {
 
     @Override
     protected int getConnTimeoutSeconds() {
-        AwsConfig awsConfig = node.getConfig().getNetworkConfig().getJoin().getAwsConfig();
+        AwsConfig awsConfig = fromDeprecatedAwsConfig(node.getConfig().getNetworkConfig().getJoin().getAwsConfig());
         return awsConfig.getConnectionTimeoutSeconds();
     }
 
     @Override
     public String getType() {
         return "aws";
+    }
+
+    static AwsConfig fromDeprecatedAwsConfig(com.hazelcast.config.AwsConfig awsConfig) {
+        return new AwsConfig()
+                .setEnabled(awsConfig.isEnabled())
+                .setAccessKey(awsConfig.getAccessKey())
+                .setSecretKey(awsConfig.getSecretKey())
+                .setRegion(awsConfig.getRegion())
+                .setSecurityGroupName(awsConfig.getSecurityGroupName())
+                .setTagKey(awsConfig.getTagKey())
+                .setTagValue(awsConfig.getTagValue())
+                .setHostHeader(awsConfig.getHostHeader())
+                .setIamRole(awsConfig.getIamRole())
+                .setConnectionTimeoutSeconds(awsConfig.getConnectionTimeoutSeconds());
+
     }
 }

--- a/src/main/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWS.java
+++ b/src/main/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWS.java
@@ -77,8 +77,7 @@ public class TcpIpJoinerOverAWS extends TcpIpJoiner {
     }
 
     static AwsConfig fromDeprecatedAwsConfig(com.hazelcast.config.AwsConfig awsConfig) {
-        return new AwsConfig()
-                .setEnabled(awsConfig.isEnabled())
+        return AwsConfig.builder()
                 .setAccessKey(awsConfig.getAccessKey())
                 .setSecretKey(awsConfig.getSecretKey())
                 .setRegion(awsConfig.getRegion())
@@ -87,7 +86,8 @@ public class TcpIpJoinerOverAWS extends TcpIpJoiner {
                 .setTagValue(awsConfig.getTagValue())
                 .setHostHeader(awsConfig.getHostHeader())
                 .setIamRole(awsConfig.getIamRole())
-                .setConnectionTimeoutSeconds(awsConfig.getConnectionTimeoutSeconds());
+                .setConnectionTimeoutSeconds(awsConfig.getConnectionTimeoutSeconds())
+                .build();
 
     }
 }

--- a/src/test/java/com/hazelcast/aws/AwsClientTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsClientTest.java
@@ -37,27 +37,30 @@ public class AwsClientTest {
 
     @Test
     public void testAwsClient_getEndPoint() {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setIamRole("test");
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setIamRole("test")
+                .build();
         AWSClient awsClient = new AWSClient(awsConfig);
         assertEquals("ec2.us-east-1.amazonaws.com", awsClient.getEndpoint());
     }
 
     @Test
     public void testAwsClient_withDifferentHostHeader() {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setIamRole("test");
-        awsConfig.setHostHeader("ec2.amazonaws.com.cn");
-        awsConfig.setRegion("cn-north-1");
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setIamRole("test")
+                .setHostHeader("ec2.amazonaws.com.cn")
+                .setRegion("cn-north-1")
+                .build();
         AWSClient awsClient = new AWSClient(awsConfig);
         assertEquals("ec2.cn-north-1.amazonaws.com.cn", awsClient.getEndpoint());
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void testAwsClient_withInvalidHostHeader() {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setIamRole("test");
-        awsConfig.setHostHeader("ec3.amazonaws.com.cn");
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setIamRole("test")
+                .setHostHeader("ec3.amazonaws.com.cn")
+                .build();
         new AWSClient(awsConfig);
     }
 }

--- a/src/test/java/com/hazelcast/aws/AwsClientTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsClientTest.java
@@ -37,7 +37,7 @@ public class AwsClientTest {
 
     @Test
     public void testAwsClient_getEndPoint() {
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setIamRole("test")
                 .build();
         AWSClient awsClient = new AWSClient(awsConfig);
@@ -46,7 +46,7 @@ public class AwsClientTest {
 
     @Test
     public void testAwsClient_withDifferentHostHeader() {
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setIamRole("test")
                 .setHostHeader("ec2.amazonaws.com.cn")
                 .setRegion("cn-north-1")
@@ -57,10 +57,17 @@ public class AwsClientTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testAwsClient_withInvalidHostHeader() {
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setIamRole("test")
                 .setHostHeader("ec3.amazonaws.com.cn")
                 .build();
         new AWSClient(awsConfig);
+    }
+
+    private static AwsConfig.Builder predefinedAwsConfigBuilder() {
+        return AwsConfig.builder()
+                .setHostHeader("ec2.amazonaws.com")
+                .setRegion("us-east-1")
+                .setConnectionTimeoutSeconds(5);
     }
 }

--- a/src/test/java/com/hazelcast/aws/AwsClientTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsClientTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.aws;
 
-import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;

--- a/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
+++ b/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.aws.impl;
 
+import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.aws.exception.AwsConnectionException;
 import com.hazelcast.aws.utility.Environment;
-import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -62,9 +62,12 @@ public class DescribeInstancesTest {
 
         final String uri = INSTANCE_METADATA_URI + IAM_SECURITY_CREDENTIALS_URI;
 
-        DescribeInstances descriptor = spy(new DescribeInstances(new AwsConfig()));
-        doReturn("").when(descriptor).retrieveRoleFromURI(uri);
-        doReturn(mockedEnv).when(descriptor).getEnvironment();
+        DescribeInstances descriptor = spy(new DescribeInstances(AwsConfig.builder()
+                .build()));
+        doReturn("").when(descriptor)
+                .retrieveRoleFromURI(uri);
+        doReturn(mockedEnv).when(descriptor)
+                .getEnvironment();
         descriptor.fillKeysFromIamRoles();
     }
 
@@ -95,8 +98,9 @@ public class DescribeInstancesTest {
 
 
         // test when <iam-role>DEFAULT</iam-role>
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setIamRole("DEFAULT");
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setIamRole("DEFAULT")
+                .build();
 
         DescribeInstances descriptor = spy(new DescribeInstances(awsConfig));
         doReturn(defaultIamRoleName).when(descriptor).retrieveRoleFromURI(uri);
@@ -108,8 +112,9 @@ public class DescribeInstancesTest {
         assertEquals("Could not parse secret key from IAM role", secretAccessKey, awsConfig.getSecretKey());
 
         // test when <iam-role></iam-role>
-        awsConfig = new AwsConfig();
-        awsConfig.setIamRole("");
+        awsConfig = AwsConfig.builder()
+                .setIamRole("")
+                .build();
 
         descriptor = spy(new DescribeInstances(awsConfig));
         doReturn(defaultIamRoleName).when(descriptor).retrieveRoleFromURI(uri);
@@ -120,7 +125,8 @@ public class DescribeInstancesTest {
         assertEquals("Could not parse secret key from IAM role", secretAccessKey, awsConfig.getSecretKey());
 
         // test when no <iam-role></iam-role> defined, BUT default IAM role has been assigned
-        awsConfig = new AwsConfig();
+        awsConfig = AwsConfig.builder()
+                .build();
 
         descriptor = spy(new DescribeInstances(awsConfig));
         doReturn(defaultIamRoleName).when(descriptor).retrieveRoleFromURI(uri);
@@ -132,12 +138,13 @@ public class DescribeInstancesTest {
 
     }
 
-
     @Test
-    public void test_whenAccessKeyExistsInConfig() throws IOException {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setAccessKey("accesskey");
-        awsConfig.setSecretKey("secretkey");
+    public void test_whenAccessKeyExistsInConfig()
+            throws IOException {
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setAccessKey("accesskey")
+                .setSecretKey("secretkey")
+                .build();
         new DescribeInstances(awsConfig, "endpoint");
     }
 
@@ -162,9 +169,9 @@ public class DescribeInstancesTest {
                         "          \"Expiration\" : \"2016-10-04T18:19:39Z\"\n" +
                         "        }\n";
 
-
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setIamRole(someRole);
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setIamRole(someRole)
+                .build();
 
         DescribeInstances descriptor = spy(new DescribeInstances(awsConfig));
         doReturn(someDummyIamRole).when(descriptor).retrieveRoleFromURI(uri);
@@ -200,7 +207,8 @@ public class DescribeInstancesTest {
         Environment mockedEnv = mock(Environment.class);
         when(mockedEnv.getEnvVar(Constants.ECS_CREDENTIALS_ENV_VAR_NAME)).thenReturn(ecsEnvVarCredsUri);
 
-        AwsConfig awsConfig = new AwsConfig();
+        AwsConfig awsConfig = AwsConfig.builder()
+                .build();
 
         // test when default role is null
         DescribeInstances descriptor = spy(new DescribeInstances(awsConfig));
@@ -218,9 +226,11 @@ public class DescribeInstancesTest {
     @Test
     public void test_DescribeInstances_SecurityGroup()
             throws Exception {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setEnabled(true).setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
-                .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY")).setSecurityGroupName("launch-wizard-147");
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
+                .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY"))
+                .setSecurityGroupName("launch-wizard-147")
+                .build();
 
         getInstancesAndVerify(awsConfig);
     }
@@ -228,9 +238,12 @@ public class DescribeInstancesTest {
     @Test
     public void test_DescribeInstances_when_Tag_and_Value_Set()
             throws Exception {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setEnabled(true).setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
-                .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY")).setTagKey("aws-test-tag").setTagValue("aws-tag-value-1");
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
+                .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY"))
+                .setTagKey("aws-test-tag")
+                .setTagValue("aws-tag-value-1")
+                .build();
 
         getInstancesAndVerify(awsConfig);
     }
@@ -238,9 +251,11 @@ public class DescribeInstancesTest {
     @Test
     public void test_DescribeInstances_when_Only_TagKey_Set()
             throws Exception {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setEnabled(true).setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
-                .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY")).setTagKey("aws-test-tag");
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
+                .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY"))
+                .setTagKey("aws-test-tag")
+                .build();
 
         getInstancesAndVerify(awsConfig);
     }
@@ -248,18 +263,22 @@ public class DescribeInstancesTest {
     @Test
     public void test_DescribeInstances_when_Only_TagValue_Set()
             throws Exception {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setEnabled(true).setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
-                .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY")).setTagValue("aws-tag-value-1");
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
+                .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY"))
+                .setTagValue("aws-tag-value-1")
+                .build();
 
         getInstancesAndVerify(awsConfig);
     }
 
     @Test(timeout = TIMEOUT_FACTOR * CALL_SERVICE_TIMEOUT, expected = SocketTimeoutException.class)
-    public void test_CallService_Timeout() throws Exception {
+    public void test_CallService_Timeout()
+            throws Exception {
         final String nonRoutable = "10.255.255.254";
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setConnectionTimeoutSeconds((int) TimeUnit.MILLISECONDS.toSeconds(CALL_SERVICE_TIMEOUT));
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setConnectionTimeoutSeconds((int) TimeUnit.MILLISECONDS.toSeconds(CALL_SERVICE_TIMEOUT))
+                .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
         describeInstances.callService(nonRoutable);
     }
@@ -272,7 +291,8 @@ public class DescribeInstancesTest {
         HttpURLConnection httpConnection = mock(HttpURLConnection.class);
         given(httpConnection.getResponseCode()).willReturn(httpResponseCode);
 
-        AwsConfig awsConfig = new AwsConfig();
+        AwsConfig awsConfig = AwsConfig.builder()
+                .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
 
         // when
@@ -292,7 +312,8 @@ public class DescribeInstancesTest {
         given(httpConnection.getResponseCode()).willReturn(httpResponseCode);
         given(httpConnection.getErrorStream()).willReturn(toInputStream(errorMessage));
 
-        AwsConfig awsConfig = new AwsConfig();
+        AwsConfig awsConfig = AwsConfig.builder()
+                .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
 
         // when & then
@@ -322,15 +343,15 @@ public class DescribeInstancesTest {
         given(httpConnection.getResponseCode()).willReturn(httpResponseCode);
         given(httpConnection.getErrorStream()).willReturn(null);
 
-        AwsConfig awsConfig = new AwsConfig();
+        AwsConfig awsConfig = AwsConfig.builder()
+                .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
 
         // when & then
         try {
             describeInstances.checkNoAwsErrors(httpConnection);
             fail("AwsConnectionFailed exception was not thrown");
-        }
-        catch (AwsConnectionException e) {
+        } catch (AwsConnectionException e) {
             assertEquals(httpResponseCode, e.getHttpReponseCode());
             assertEquals("", e.getErrorMessage());
             assertThat(e.getMessage(), containsString(Integer.toString(httpResponseCode)));
@@ -340,8 +361,9 @@ public class DescribeInstancesTest {
     @Test(timeout = TIMEOUT_FACTOR * CALL_SERVICE_TIMEOUT, expected = InvalidConfigurationException.class)
     public void test_RetrieveMetaData_Timeout() {
         final String nonRoutable = "http://10.255.255.254";
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setConnectionTimeoutSeconds((int) TimeUnit.MILLISECONDS.toSeconds(CALL_SERVICE_TIMEOUT));
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setConnectionTimeoutSeconds((int) TimeUnit.MILLISECONDS.toSeconds(CALL_SERVICE_TIMEOUT))
+                .build();
 
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
         describeInstances.retrieveRoleFromURI(nonRoutable);

--- a/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
+++ b/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
@@ -62,7 +62,7 @@ public class DescribeInstancesTest {
 
         final String uri = INSTANCE_METADATA_URI + IAM_SECURITY_CREDENTIALS_URI;
 
-        DescribeInstances descriptor = spy(new DescribeInstances(AwsConfig.builder()
+        DescribeInstances descriptor = spy(new DescribeInstances(predefinedAwsConfigBuilder()
                 .build()));
         doReturn("").when(descriptor)
                 .retrieveRoleFromURI(uri);
@@ -98,7 +98,7 @@ public class DescribeInstancesTest {
 
 
         // test when <iam-role>DEFAULT</iam-role>
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setIamRole("DEFAULT")
                 .build();
 
@@ -112,7 +112,7 @@ public class DescribeInstancesTest {
         assertEquals("Could not parse secret key from IAM role", secretAccessKey, awsConfig.getSecretKey());
 
         // test when <iam-role></iam-role>
-        awsConfig = AwsConfig.builder()
+        awsConfig = predefinedAwsConfigBuilder()
                 .setIamRole("")
                 .build();
 
@@ -125,7 +125,7 @@ public class DescribeInstancesTest {
         assertEquals("Could not parse secret key from IAM role", secretAccessKey, awsConfig.getSecretKey());
 
         // test when no <iam-role></iam-role> defined, BUT default IAM role has been assigned
-        awsConfig = AwsConfig.builder()
+        awsConfig = predefinedAwsConfigBuilder()
                 .build();
 
         descriptor = spy(new DescribeInstances(awsConfig));
@@ -141,7 +141,7 @@ public class DescribeInstancesTest {
     @Test
     public void test_whenAccessKeyExistsInConfig()
             throws IOException {
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setAccessKey("accesskey")
                 .setSecretKey("secretkey")
                 .build();
@@ -169,7 +169,7 @@ public class DescribeInstancesTest {
                         "          \"Expiration\" : \"2016-10-04T18:19:39Z\"\n" +
                         "        }\n";
 
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setIamRole(someRole)
                 .build();
 
@@ -207,7 +207,7 @@ public class DescribeInstancesTest {
         Environment mockedEnv = mock(Environment.class);
         when(mockedEnv.getEnvVar(Constants.ECS_CREDENTIALS_ENV_VAR_NAME)).thenReturn(ecsEnvVarCredsUri);
 
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .build();
 
         // test when default role is null
@@ -226,7 +226,7 @@ public class DescribeInstancesTest {
     @Test
     public void test_DescribeInstances_SecurityGroup()
             throws Exception {
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
                 .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY"))
                 .setSecurityGroupName("launch-wizard-147")
@@ -238,7 +238,7 @@ public class DescribeInstancesTest {
     @Test
     public void test_DescribeInstances_when_Tag_and_Value_Set()
             throws Exception {
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
                 .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY"))
                 .setTagKey("aws-test-tag")
@@ -251,7 +251,7 @@ public class DescribeInstancesTest {
     @Test
     public void test_DescribeInstances_when_Only_TagKey_Set()
             throws Exception {
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
                 .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY"))
                 .setTagKey("aws-test-tag")
@@ -263,7 +263,7 @@ public class DescribeInstancesTest {
     @Test
     public void test_DescribeInstances_when_Only_TagValue_Set()
             throws Exception {
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setAccessKey(System.getenv("AWS_ACCESS_KEY_ID"))
                 .setSecretKey(System.getenv("AWS_SECRET_ACCESS_KEY"))
                 .setTagValue("aws-tag-value-1")
@@ -276,7 +276,7 @@ public class DescribeInstancesTest {
     public void test_CallService_Timeout()
             throws Exception {
         final String nonRoutable = "10.255.255.254";
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setConnectionTimeoutSeconds((int) TimeUnit.MILLISECONDS.toSeconds(CALL_SERVICE_TIMEOUT))
                 .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
@@ -291,7 +291,7 @@ public class DescribeInstancesTest {
         HttpURLConnection httpConnection = mock(HttpURLConnection.class);
         given(httpConnection.getResponseCode()).willReturn(httpResponseCode);
 
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
 
@@ -312,7 +312,7 @@ public class DescribeInstancesTest {
         given(httpConnection.getResponseCode()).willReturn(httpResponseCode);
         given(httpConnection.getErrorStream()).willReturn(toInputStream(errorMessage));
 
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
 
@@ -343,7 +343,7 @@ public class DescribeInstancesTest {
         given(httpConnection.getResponseCode()).willReturn(httpResponseCode);
         given(httpConnection.getErrorStream()).willReturn(null);
 
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig);
 
@@ -361,7 +361,7 @@ public class DescribeInstancesTest {
     @Test(timeout = TIMEOUT_FACTOR * CALL_SERVICE_TIMEOUT, expected = InvalidConfigurationException.class)
     public void test_RetrieveMetaData_Timeout() {
         final String nonRoutable = "http://10.255.255.254";
-        AwsConfig awsConfig = AwsConfig.builder()
+        AwsConfig awsConfig = predefinedAwsConfigBuilder()
                 .setConnectionTimeoutSeconds((int) TimeUnit.MILLISECONDS.toSeconds(CALL_SERVICE_TIMEOUT))
                 .build();
 
@@ -378,5 +378,12 @@ public class DescribeInstancesTest {
         String expectedPrivateIp = System.getenv("HZ_TEST_AWS_INSTANCE_PRIVATE_IP");
         Assert.assertNotNull(expectedPrivateIp);
         Assert.assertNotNull(result.get(expectedPrivateIp));
+    }
+
+    private static AwsConfig.Builder predefinedAwsConfigBuilder() {
+        return AwsConfig.builder()
+                .setHostHeader("ec2.amazonaws.com")
+                .setRegion("us-east-1")
+                .setConnectionTimeoutSeconds(5);
     }
 }

--- a/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
+++ b/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.aws.impl;
 
 import com.hazelcast.aws.exception.AwsConnectionException;
 import com.hazelcast.aws.utility.Environment;
-import com.hazelcast.config.AwsConfig;
+import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;

--- a/src/test/java/com/hazelcast/aws/security/EC2RequestSignerTest.java
+++ b/src/test/java/com/hazelcast/aws/security/EC2RequestSignerTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.aws.security;
 
 import com.hazelcast.aws.impl.DescribeInstances;
-import com.hazelcast.config.AwsConfig;
+import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;

--- a/src/test/java/com/hazelcast/aws/security/EC2RequestSignerTest.java
+++ b/src/test/java/com/hazelcast/aws/security/EC2RequestSignerTest.java
@@ -47,11 +47,11 @@ public class EC2RequestSignerTest {
     @Test
     public void deriveSigningKeyTest() throws Exception {
         // this is from http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setRegion(TEST_REGION).
+        AwsConfig awsConfig = AwsConfig.builder()
+        .setRegion(TEST_REGION).
                 setHostHeader(TEST_HOST).
                 setAccessKey(TEST_ACCESS_KEY).
-                setSecretKey(TEST_SECRET_KEY);
+                setSecretKey(TEST_SECRET_KEY).build();
 
         DescribeInstances di = new DescribeInstances(awsConfig, TEST_HOST);
         // Override the attributes map. We need to change values. Not pretty, but
@@ -78,11 +78,11 @@ public class EC2RequestSignerTest {
 
     @Test
     public void testSigning() throws NoSuchFieldException, IllegalAccessException, IOException {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setRegion(TEST_REGION).
+        AwsConfig awsConfig = AwsConfig.builder()
+        .setRegion(TEST_REGION).
                 setHostHeader(TEST_HOST).
                 setAccessKey(TEST_ACCESS_KEY).
-                setSecretKey(TEST_SECRET_KEY);
+                setSecretKey(TEST_SECRET_KEY).build();
 
         DescribeInstances di = new DescribeInstances(awsConfig, TEST_HOST);
         di.getRequestSigner();

--- a/src/test/java/com/hazelcast/aws/utility/CloudyUtilityTest.java
+++ b/src/test/java/com/hazelcast/aws/utility/CloudyUtilityTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.aws.utility;
 
 import com.hazelcast.aws.impl.DescribeInstances;
-import com.hazelcast.config.AwsConfig;
+import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;

--- a/src/test/java/com/hazelcast/aws/utility/CloudyUtilityTest.java
+++ b/src/test/java/com/hazelcast/aws/utility/CloudyUtilityTest.java
@@ -44,10 +44,11 @@ public class CloudyUtilityTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        awsConfig = new AwsConfig();
-        awsConfig.setAccessKey("some-access-key");
-        awsConfig.setSecretKey("some-secret-key");
-        awsConfig.setSecurityGroupName("hazelcast");
+        awsConfig = AwsConfig.builder()
+                .setAccessKey("some-access-key")
+                .setSecretKey("some-secret-key")
+                .setSecurityGroupName("hazelcast")
+                .build();
     }
 
     @Test
@@ -58,9 +59,10 @@ public class CloudyUtilityTest extends HazelcastTestSupport {
     @Test
     public void testUnmarshalling() throws IOException {
         InputStream is = new ByteArrayInputStream(xml.getBytes());
-        AwsConfig awsConfig1 = new AwsConfig();
-        awsConfig1.setAccessKey("some-access-key");
-        awsConfig1.setSecretKey("some-secret-key");
+        AwsConfig awsConfig1 = AwsConfig.builder()
+                .setAccessKey("some-access-key")
+                .setSecretKey("some-secret-key")
+                .build();
 
         Map<String, String> result = CloudyUtility.unmarshalTheResponse(is);
         assertEquals(2, result.size());
@@ -78,10 +80,11 @@ public class CloudyUtilityTest extends HazelcastTestSupport {
                 + "  \"Expiration\" : \"2015-09-07T03:19:56Z\"\n}";
         StringReader sr = new StringReader(s);
         BufferedReader br = new BufferedReader(sr);
-        AwsConfig awsConfig1 = new AwsConfig();
-        awsConfig1.setAccessKey("some-access-key");
-        awsConfig1.setSecretKey("some-secret-key");
-        awsConfig1.setSecurityGroupName("hazelcast");
+        AwsConfig awsConfig1 = AwsConfig.builder()
+                .setAccessKey("some-access-key")
+                .setSecretKey("some-secret-key")
+                .setSecurityGroupName("hazelcast")
+                .build();
         DescribeInstances describeInstances = new DescribeInstances(awsConfig, "");
 
         Map map = describeInstances.parseIamRole(br);

--- a/src/test/java/com/hazelcast/aws/utility/RetryUtilsTest.java
+++ b/src/test/java/com/hazelcast/aws/utility/RetryUtilsTest.java
@@ -1,0 +1,84 @@
+package com.hazelcast.aws.utility;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class RetryUtilsTest {
+    private static final Integer RETRIES = 3;
+    private static final String RESULT = "result string";
+
+    private Callable<String> callable = mock(Callable.class);
+
+    @Test
+    public void retryNoRetries()
+            throws Exception {
+        // given
+        given(callable.call()).willReturn(RESULT);
+
+        // when
+        String result = RetryUtils.retry(callable, RETRIES);
+
+        // then
+        assertEquals(RESULT, result);
+        verify(callable).call();
+    }
+
+    @Test
+    public void retryRetriesSuccessful()
+            throws Exception {
+        // given
+        given(callable.call()).willThrow(new RuntimeException()).willThrow(new RuntimeException())
+                              .willThrow(new RuntimeException()).willReturn(RESULT);
+
+        // when
+        String result = RetryUtils.retry(callable, RETRIES);
+
+        // then
+        assertEquals(RESULT, result);
+        verify(callable, times(4)).call();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void retryRetriesFailed()
+            throws Exception {
+        // given
+        given(callable.call()).willThrow(new RuntimeException()).willThrow(new RuntimeException())
+                              .willThrow(new RuntimeException()).willThrow(new RuntimeException()).willReturn(RESULT);
+
+        // when
+        RetryUtils.retry(callable, RETRIES);
+
+        // then
+        // throws exception
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void retryRetriesFailedUncheckedException()
+            throws Exception {
+        // given
+        given(callable.call()).willThrow(new Exception()).willThrow(new Exception()).willThrow(new Exception())
+                              .willThrow(new Exception()).willReturn(RESULT);
+
+        // when
+        RetryUtils.retry(callable, RETRIES);
+
+        // then
+        // throws exception
+    }
+
+}

--- a/src/test/java/com/hazelcast/aws/utility/RetryUtilsTest.java
+++ b/src/test/java/com/hazelcast/aws/utility/RetryUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.aws.utility;
 
 import com.hazelcast.core.HazelcastException;

--- a/src/test/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWSTest.java
+++ b/src/test/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWSTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.cluster.impl;
 
 import com.hazelcast.cluster.Joiner;
-import com.hazelcast.aws.AwsConfig;
+import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.instance.DefaultNodeContext;
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.nio.channels.ServerSocketChannel;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.hazelcast.cluster.impl.TcpIpJoinerOverAWS.fromDeprecatedAwsConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -51,9 +50,10 @@ public class TcpIpJoinerOverAWSTest extends HazelcastTestSupport {
         JoinConfig join = config.getNetworkConfig().getJoin();
         join.getMulticastConfig().setEnabled(false);
 
-        AwsConfig awsConfig = fromDeprecatedAwsConfig(join.getAwsConfig());
-        awsConfig.setAccessKey(randomString());
-        awsConfig.setSecretKey(randomString());
+        AwsConfig awsConfig = join.getAwsConfig();
+        awsConfig.setEnabled(true)
+                .setAccessKey(randomString())
+                .setSecretKey(randomString());
 
         HazelcastInstanceImpl instance = Mockito.mock(HazelcastInstanceImpl.class);
 

--- a/src/test/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWSTest.java
+++ b/src/test/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWSTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.cluster.impl;
 
 import com.hazelcast.cluster.Joiner;
-import com.hazelcast.config.AwsConfig;
+import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.instance.DefaultNodeContext;
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.channels.ServerSocketChannel;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hazelcast.cluster.impl.TcpIpJoinerOverAWS.fromDeprecatedAwsConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -50,7 +51,7 @@ public class TcpIpJoinerOverAWSTest extends HazelcastTestSupport {
         JoinConfig join = config.getNetworkConfig().getJoin();
         join.getMulticastConfig().setEnabled(false);
 
-        AwsConfig awsConfig = join.getAwsConfig();
+        AwsConfig awsConfig = fromDeprecatedAwsConfig(join.getAwsConfig());
         awsConfig.setEnabled(true)
                 .setAccessKey(randomString())
                 .setSecretKey(randomString());

--- a/src/test/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWSTest.java
+++ b/src/test/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWSTest.java
@@ -52,9 +52,8 @@ public class TcpIpJoinerOverAWSTest extends HazelcastTestSupport {
         join.getMulticastConfig().setEnabled(false);
 
         AwsConfig awsConfig = fromDeprecatedAwsConfig(join.getAwsConfig());
-        awsConfig.setEnabled(true)
-                .setAccessKey(randomString())
-                .setSecretKey(randomString());
+        awsConfig.setAccessKey(randomString());
+        awsConfig.setSecretKey(randomString());
 
         HazelcastInstanceImpl instance = Mockito.mock(HazelcastInstanceImpl.class);
 

--- a/src/test/resources/test-aws-config.xml
+++ b/src/test/resources/test-aws-config.xml
@@ -40,6 +40,7 @@
                         <property name="tag-key">test-tag-key</property>
                         <property name="tag-value">test-tag-value</property>
                         <property name="connection-timeout-seconds">10</property>
+                        <property name="connection-retries">10</property>
                         <property name="hz-port">5702</property>
                     </properties>
                 </discovery-strategy>


### PR DESCRIPTION
Add retrying mechanism for AWS endpoint calls.

fix #64 

Changes:
- Add property: "connection-retries" which specifies the number of retries if AWS endpoint connection fails
- Add retrying mechanism for `DescribeInstances` and `MetadataUtil`
- Extract com.hazelcast.aws.AwsConfig from com.hazelcast.config.AwsConfig (before the config for the discovery was stored in hazelcast-root and shared with the deprecated method of nodes discovery)
- Refactor: Move setting default parameters to `AwsDiscoveryStrategy` (before it was partly in `AwsDiscoveryStrategy`, partly in `AwsConfig`)
- Refactor: Move `hzPort` into `AwsConfig`
- Change not to throw an exception but to log it and return an empty collection (prevent node crash when AWS services are overloaded)