### PR TITLE
Make plugin compiable with 3.12-SNAPSHOT + 3.11.1 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>
-        <hazelcast.version>3.11</hazelcast.version>
+        <hazelcast.version>3.11.1</hazelcast.version>
 
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/com/hazelcast/aws/utility/CloudyUtility.java
+++ b/src/main/java/com/hazelcast/aws/utility/CloudyUtility.java
@@ -30,8 +30,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.hazelcast.config.AbstractXmlConfigHelper.childElements;
-import static com.hazelcast.config.AbstractXmlConfigHelper.cleanNodeName;
+import static com.hazelcast.config.DomConfigHelper.childElements;
+import static com.hazelcast.config.DomConfigHelper.cleanNodeName;
 import static java.lang.String.format;
 
 public final class CloudyUtility {

--- a/src/main/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWS.java
+++ b/src/main/java/com/hazelcast/cluster/impl/TcpIpJoinerOverAWS.java
@@ -76,12 +76,6 @@ public class TcpIpJoinerOverAWS
     }
 
     @Override
-    protected int getConnTimeoutSeconds() {
-        AwsConfig awsConfig = fromDeprecatedAwsConfig(node.getConfig().getNetworkConfig().getJoin().getAwsConfig());
-        return awsConfig.getConnectionTimeoutSeconds();
-    }
-
-    @Override
     public String getType() {
         return "aws";
     }


### PR DESCRIPTION
I'm going to be honest - I haven't tested it. I just noticed that master branch with master IMDG doesn't compile. Here's perhaps a way how to fix it.

The getConnTimeoutSeconds removal is caused by this change: https://github.com/hazelcast/hazelcast/commit/21cf7b8ea9b7b9ce5b9098b7d3d4e46725072a2a#diff-fb245e855ae859c129d6876ed8160ddbR75

I don't know if it's a right solution.