### PR TITLE
Hazelcast 4.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jdk.version>1.6</jdk.version>
-        <hazelcast.version>3.12-BETA-1</hazelcast.version>
+        <jdk.version>1.8</jdk.version>
+        <hazelcast.version>4.0-SNAPSHOT</hazelcast.version>
 
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -62,7 +62,7 @@ public class AwsDiscoveryStrategy
     private final AwsConfig awsConfig;
     private final AWSClient awsClient;
 
-    private final Map<String, Object> memberMetadata = new HashMap<String, Object>();
+    private final Map<String, String> memberMetadata = new HashMap<String, String>();
 
     public AwsDiscoveryStrategy(Map<String, Comparable> properties) {
         super(LOGGER, properties);
@@ -133,7 +133,7 @@ public class AwsDiscoveryStrategy
     }
 
     @Override
-    public Map<String, Object> discoverLocalMetadata() {
+    public Map<String, String> discoverLocalMetadata() {
         if (memberMetadata.isEmpty()) {
             memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_ZONE, awsClient.getAvailabilityZone());
         }

--- a/src/test/java/com/hazelcast/aws/AwsClientTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsClientTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.aws;
 
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AwsClientTest {
 
     private static AwsConfig.Builder predefinedAwsConfigBuilder() {

--- a/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
@@ -51,7 +51,7 @@ public class AwsDiscoveryStrategyTest
         given(mockClient.getAvailabilityZone()).willReturn("us-east-1a");
 
         // when
-        Map<String, Object> localMetaData = awsDiscoveryStrategy.discoverLocalMetadata();
+        Map<String, String> localMetaData = awsDiscoveryStrategy.discoverLocalMetadata();
 
         // then
         assertEquals("us-east-1a", localMetaData.get(PARTITION_GROUP_ZONE));

--- a/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
+++ b/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.aws.AwsConfig;
 import com.hazelcast.aws.exception.AwsConnectionException;
 import com.hazelcast.aws.utility.Environment;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class DescribeInstancesTest {
     public static final String DUMMY_PRIVATE_IP = "10.0.0.1";
     private static final String DUMMY_ACCESS_KEY = "DUMMY_ACCESS_KEY";

--- a/src/test/java/com/hazelcast/aws/utility/RetryUtilsTest.java
+++ b/src/test/java/com/hazelcast/aws/utility/RetryUtilsTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.aws.utility;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class RetryUtilsTest {
     private static final Integer RETRIES = 1;
     private static final String RESULT = "result string";


### PR DESCRIPTION
* upgraded main hazelcast version to 4.0-SNAPSHOT
* fixed compile errors
* convert `ParallelTest` into `ParallelJVMTest`