### PR TITLE
disable doclint at maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-        <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
 
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
@@ -189,40 +189,6 @@
                     </argLine>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.plugin.version}</version>
-                <configuration>
-                    <javaApiLinks>
-                        <property>
-                            <name>api_1.6</name>
-                            <value>http://download.oracle.com/javase/1.6.0/docs/api/</value>
-                        </property>
-                        <property>
-                            <name>api_1.7</name>
-                            <value>http://download.oracle.com/javase/1.7.0/docs/api/</value>
-                        </property>
-                    </javaApiLinks>
-                    <excludePackageNames>
-                        *.impl:*.internal:*.operations:*.proxy:*.util:com.hazelcast.aws.security:com:hazelcast:aws:
-                        *.handlermigration:*.client.connection.nio:*.client.console:*.buildutils:
-                        *.client.protocol.generator:*.cluster.client:*.concurrent:*.collection:
-                        *.nio.ascii:*.nio.ssl:*.nio.tcp:*.partition.client:*.transaction.client:
-                        *.core.server:com.hazelcast.instance:com.hazelcast.PlaceHolder
-                    </excludePackageNames>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 
@@ -465,6 +431,7 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven.javadoc.plugin.version}</version>
                         <configuration>
+                            <doclint>none</doclint>
                             <javaApiLinks>
                                 <property>
                                     <name>api_1.6</name>
@@ -514,6 +481,7 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven.javadoc.plugin.version}</version>
                         <configuration>
+                            <doclint>none</doclint>
                             <javaApiLinks>
                                 <property>
                                     <name>api_1.6</name>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,39 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.version}</version>
+                <configuration>
+                    <javaApiLinks>
+                        <property>
+                            <name>api_1.6</name>
+                            <value>http://download.oracle.com/javase/1.6.0/docs/api/</value>
+                        </property>
+                        <property>
+                            <name>api_1.7</name>
+                            <value>http://download.oracle.com/javase/1.7.0/docs/api/</value>
+                        </property>
+                    </javaApiLinks>
+                    <excludePackageNames>
+                        *.impl:*.internal:*.operations:*.proxy:*.util:com.hazelcast.aws.security:com:hazelcast:aws:
+                        *.handlermigration:*.client.connection.nio:*.client.console:*.buildutils:
+                        *.client.protocol.generator:*.cluster.client:*.concurrent:*.collection:
+                        *.nio.ascii:*.nio.ssl:*.nio.tcp:*.partition.client:*.transaction.client:
+                        *.core.server:com.hazelcast.instance:com.hazelcast.PlaceHolder
+                    </excludePackageNames>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-        <maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
 
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-        <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>
 
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>


### PR DESCRIPTION
Our deployment build is failing due to below errors:
```
14:18:26 [ERROR] /home/jenkins/jenkins_slave/workspace/AWS-deploy/src/main/java/com/hazelcast/aws/utility/RetryUtils.java:47: warning: no @param for <T>
14:18:26 [ERROR]     public static <T> T retry(Callable<T> callable, int retries) {
14:18:26 [ERROR]                         ^
14:18:26 [ERROR] /home/jenkins/jenkins_slave/workspace/AWS-deploy/src/main/java/com/hazelcast/aws/utility/RetryUtils.java:47: warning: no @param for callable
14:18:26 [ERROR]     public static <T> T retry(Callable<T> callable, int retries) {
14:18:26 [ERROR]                         ^
14:18:26 [ERROR] /home/jenkins/jenkins_slave/workspace/AWS-deploy/src/main/java/com/hazelcast/aws/utility/RetryUtils.java:47: warning: no @param for retries
14:18:26 [ERROR]     public static <T> T retry(Callable<T> callable, int retries) {
14:18:26 [ERROR]                         ^
14:18:26 [ERROR] /home/jenkins/jenkins_slave/workspace/AWS-deploy/src/main/java/com/hazelcast/aws/utility/RetryUtils.java:47: warning: no @return
14:18:26 [ERROR]     public static <T> T retry(Callable<T> callable, int retries) {
14:18:26 [ERROR]                         ^
14:18:26 [ERROR] /home/jenkins/jenkins_slave/workspace/AWS-deploy/src/main/java/com/hazelcast/aws/AwsConfig.java:69: warning: no @param for accessKey
14:18:26 [ERROR]     public void setAccessKey(String accessKey) {
14:18:26 [ERROR]                 ^
14:18:26 [ERROR] /home/jenkins/jenkins_slave/workspace/AWS-deploy/src/main/java/com/hazelcast/aws/AwsConfig.java:83: warning: no @param for secretKey
14:18:26 [ERROR]     public void setSecretKey(String secretKey) {
14:18:26 [ERROR]                 ^
14:18:26 [ERROR] /home/jenkins/jenkins_slave/workspace/AWS-deploy/src/main/java/com/hazelcast/aws/AwsConfig.java:101: warning: no @param for iamRole
14:18:26 [ERROR]     public void setIamRole(String iamRole) {
```