### PR TITLE
Fix too strict test conditions (failing Jenkins master)

### DIFF
--- a/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
@@ -284,8 +284,7 @@ public class AwsEc2ApiTest {
             .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
 
         // when
-        RestClientException exception = assertThrows(RestClientException.class,
-            () -> awsEc2Api.describeInstances(CREDENTIALS));
+        Exception exception = assertThrows(Exception.class, () -> awsEc2Api.describeInstances(CREDENTIALS));
 
         // then
         assertTrue(exception.getMessage().contains(Integer.toString(errorCode)));

--- a/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
@@ -224,8 +224,7 @@ public class AwsEcsApiTest {
             .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
 
         // when
-        RestClientException exception = assertThrows(RestClientException.class,
-            () -> awsEcsApi.listTasks("cluster-arn", CREDENTIALS));
+        Exception exception = assertThrows(Exception.class, () -> awsEcsApi.listTasks("cluster-arn", CREDENTIALS));
 
         // then
         assertTrue(exception.getMessage().contains(Integer.toString(errorCode)));

--- a/src/test/java/com/hazelcast/aws/AwsMetadataApiTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsMetadataApiTest.java
@@ -144,8 +144,7 @@ public class AwsMetadataApiTest {
             .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
 
         // when
-        RestClientException exception = assertThrows(RestClientException.class,
-            () -> awsMetadataApi.defaultIamRoleEc2());
+        Exception exception = assertThrows(Exception.class, () -> awsMetadataApi.defaultIamRoleEc2());
 
         // then
         assertTrue(exception.getMessage().contains(Integer.toString(errorCode)));

--- a/src/test/java/com/hazelcast/aws/RestClientTest.java
+++ b/src/test/java/com/hazelcast/aws/RestClientTest.java
@@ -101,7 +101,7 @@ public class RestClientTest {
         assertEquals(BODY_RESPONSE, result);
     }
 
-    @Test(expected = RestClientException.class)
+    @Test(expected = Exception.class)
     public void getFailure() {
         // given
         stubFor(get(urlEqualTo(API_ENDPOINT))


### PR DESCRIPTION
Fix Jenkins master build http://jenkins.hazelcast.com/job/AWS-master/348/.

The conditions of the tests were too strict and the change in the Core part (the change of what exception is thrown) caused the test failures.