### PR TITLE
Implement auto-detection and improve logs

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -21,8 +21,13 @@
         <Bug pattern="SE_BAD_FIELD_STORE"/>
     </Match>
     <Match>
-        <!-- AwsEc2RequestSigner should always use '\n' as new line (and not platform-specific '%n' -->
+        <!-- AwsEc2RequestSigner should always use '\n' as new line (and not platform-specific '%n') -->
         <Class name="com.hazelcast.aws.AwsRequestSigner"/>
         <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+    </Match>
+    <Match>
+        <!-- We need an absolute path -->
+        <Class name="com.hazelcast.aws.AwsDiscoveryStrategyFactory"/>
+        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
     </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.8</jdk.version>
-        <hazelcast.version>4.0.2</hazelcast.version>
+        <hazelcast.version>4.1-SNAPSHOT</hazelcast.version>
 
         <junit.version>4.13</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/com/hazelcast/aws/AwsCredentialsProvider.java
+++ b/src/main/java/com/hazelcast/aws/AwsCredentialsProvider.java
@@ -56,6 +56,7 @@ class AwsCredentialsProvider {
             return ec2IamRole;
         } catch (RestClientException e) {
             if (e.getHttpErrorCode() == 404) {
+                // no IAM Role attached to EC2 instance, no need to log any warning at this point
                 LOGGER.finest("IAM Role not found", e);
             } else {
                 LOGGER.warning("Couldn't retrieve IAM Role from EC2 instance", e);

--- a/src/main/java/com/hazelcast/aws/AwsCredentialsProvider.java
+++ b/src/main/java/com/hazelcast/aws/AwsCredentialsProvider.java
@@ -22,6 +22,8 @@ import com.hazelcast.logging.Logger;
 class AwsCredentialsProvider {
     private static final ILogger LOGGER = Logger.getLogger(AwsCredentialsProvider.class);
 
+    private static final int HTTP_NOT_FOUND = 404;
+
     private final AwsConfig awsConfig;
     private final AwsMetadataApi awsMetadataApi;
     private final Environment environment;
@@ -55,7 +57,7 @@ class AwsCredentialsProvider {
             LOGGER.info(String.format("Using IAM Role attached to EC2 Instance: '%s'", ec2IamRole));
             return ec2IamRole;
         } catch (RestClientException e) {
-            if (e.getHttpErrorCode() == 404) {
+            if (e.getHttpErrorCode() == HTTP_NOT_FOUND) {
                 // no IAM Role attached to EC2 instance, no need to log any warning at this point
                 LOGGER.finest("IAM Role not found", e);
             } else {

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -152,7 +152,7 @@ public class AwsDiscoveryStrategy
         } catch (NoCredentialsException e) {
             if (!isNoCredentialsExceptionAlreadyLogged) {
                 LOGGER.warning("No AWS credentials found! Starting standalone. To use Hazelcast AWS discovery, configure"
-                        + "(access-key, secret-key) properties or assign the needed IAM Role to your EC2 instance");
+                        + " properties (access-key, secret-key) or assign the required IAM Role to your EC2 instance");
                 isNoCredentialsExceptionAlreadyLogged = true;
             }
         } catch (Exception e) {

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -159,7 +159,7 @@ public class AwsDiscoveryStrategy
         } catch (RestClientException e) {
             if (e.getHttpErrorCode() == 403) {
                 if (!isKnownExceptionAlreadyLogged) {
-                    LOGGER.warning("AWS IAM Role Policy is missing 'ec2:DescribeInstances' Action! Starting standalone.");
+                    LOGGER.warning("AWS IAM Role Policy missing 'ec2:DescribeInstances' Action! Starting standalone.");
                     isKnownExceptionAlreadyLogged = true;
                 }
                 LOGGER.finest(e);

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -56,6 +56,8 @@ public class AwsDiscoveryStrategy
         extends AbstractDiscoveryStrategy {
     private static final ILogger LOGGER = Logger.getLogger(AwsDiscoveryStrategy.class);
 
+    private static final int HTTP_FORBIDDEN = 403;
+
     private static final String DEFAULT_PORT_RANGE = "5701-5708";
     private static final Integer DEFAULT_CONNECTION_RETRIES = 3;
     private static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10;
@@ -157,7 +159,7 @@ public class AwsDiscoveryStrategy
                 isKnownExceptionAlreadyLogged = true;
             }
         } catch (RestClientException e) {
-            if (e.getHttpErrorCode() == 403) {
+            if (e.getHttpErrorCode() == HTTP_FORBIDDEN) {
                 if (!isKnownExceptionAlreadyLogged) {
                     LOGGER.warning("AWS IAM Role Policy missing 'ec2:DescribeInstances' Action! Starting standalone.");
                     isKnownExceptionAlreadyLogged = true;

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -53,7 +53,7 @@ import static com.hazelcast.aws.AwsProperties.TAG_VALUE;
  * @see AwsClient
  */
 public class AwsDiscoveryStrategy
-    extends AbstractDiscoveryStrategy {
+        extends AbstractDiscoveryStrategy {
     private static final ILogger LOGGER = Logger.getLogger(AwsDiscoveryStrategy.class);
 
     private static final String DEFAULT_PORT_RANGE = "5701-5708";
@@ -147,15 +147,20 @@ public class AwsDiscoveryStrategy
                 }
             }
             return result;
+        } catch (NoCredentialsException e) {
+            LOGGER.warning("No AWS credentials found! Starting standalone. To use Hazelcast AWS discovery, configure"
+                    + "(access-key, secret-key) properties or assign the needed IAM Role to your EC2 instance"
+            );
+
         } catch (Exception e) {
-            LOGGER.warning("Cannot discover nodes, returning empty list", e);
-            return Collections.emptyList();
+            LOGGER.warning("Cannot discover nodes. Starting standalone.", e);
         }
+        return Collections.emptyList();
     }
 
     private static void logResult(Map<String, String> addresses) {
         if (addresses.isEmpty()) {
-            LOGGER.warning("No IP addresses found!");
+            LOGGER.warning("No IP addresses found! Starting standalone.");
         }
 
         LOGGER.fine(String.format("Found the following (private => public) addresses: %s", addresses));

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -66,6 +66,8 @@ public class AwsDiscoveryStrategy
 
     private final Map<String, String> memberMetadata = new HashMap<>();
 
+    private boolean isNoCredentialsExceptionAlreadyLogged;
+
     AwsDiscoveryStrategy(Map<String, Comparable> properties) {
         super(LOGGER, properties);
 
@@ -148,10 +150,11 @@ public class AwsDiscoveryStrategy
             }
             return result;
         } catch (NoCredentialsException e) {
-            LOGGER.warning("No AWS credentials found! Starting standalone. To use Hazelcast AWS discovery, configure"
-                    + "(access-key, secret-key) properties or assign the needed IAM Role to your EC2 instance"
-            );
-
+            if (!isNoCredentialsExceptionAlreadyLogged) {
+                LOGGER.warning("No AWS credentials found! Starting standalone. To use Hazelcast AWS discovery, configure"
+                        + "(access-key, secret-key) properties or assign the needed IAM Role to your EC2 instance");
+                isNoCredentialsExceptionAlreadyLogged = true;
+            }
         } catch (Exception e) {
             LOGGER.warning("Cannot discover nodes. Starting standalone.", e);
         }

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -93,9 +93,8 @@ public class AwsDiscoveryStrategyFactory
     }
 
     private static boolean instanceIdentityExists() {
-        String url = "http://169.254.169.254/latest/dynamic/instance-identity/";
         try {
-            return isEndpointAvailable(url);
+            return isEndpointAvailable("http://169.254.169.254/latest/dynamic/instance-identity/");
         } catch (Exception e) {
             // any exception means that we're not running on AWS
             return false;
@@ -103,23 +102,27 @@ public class AwsDiscoveryStrategyFactory
     }
 
     private static boolean iamRoleAttached() {
-        String url = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
         try {
-            return isEndpointAvailable(url);
+            return isEndpointAvailable("http://169.254.169.254/latest/meta-data/iam/security-credentials/");
         } catch (Exception e) {
             LOGGER.warning("Hazelcast running on EC2 instance, but no IAM Role attached. Cannot use Hazelcast AWS discovery.");
             return false;
         }
     }
 
-    private static boolean isEndpointAvailable(String url) throws Exception {
+    static boolean isEndpointAvailable(String url) {
         int timeoutInSeconds = 1;
-        return !RestClient.create(url)
-                .withConnectTimeoutSeconds(timeoutInSeconds)
-                .withReadTimeoutSeconds(timeoutInSeconds)
-                .withRetries(0)
-                .get()
-                .isEmpty();
+        try {
+            return !RestClient.create(url)
+                    .withConnectTimeoutSeconds(timeoutInSeconds)
+                    .withReadTimeoutSeconds(timeoutInSeconds)
+                    .withRetries(0)
+                    .get()
+                    .isEmpty();
+        } catch (Exception e) {
+            // any exception means that connecting to the endpoint does not work
+            return false;
+        }
     }
 
     private static boolean isRunningOnEcs() {

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -76,12 +76,7 @@ public class AwsDiscoveryStrategyFactory
      */
     @Override
     public boolean isAutoDetectionApplicable() {
-        try {
-            return isRunningOnEc2() && !isRunningOnEcs();
-        } catch (Exception e) {
-            LOGGER.finest(e);
-            return false;
-        }
+        return isRunningOnEc2() && !isRunningOnEcs();
     }
 
     private static boolean isRunningOnEc2() {

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -122,10 +122,9 @@ public class AwsDiscoveryStrategyFactory
     }
 
     static boolean isEndpointAvailable(String url) {
-        int timeoutInSeconds = 1;
         return !RestClient.create(url)
-                .withConnectTimeoutSeconds(timeoutInSeconds)
-                .withReadTimeoutSeconds(timeoutInSeconds)
+                .withConnectTimeoutSeconds(1)
+                .withReadTimeoutSeconds(1)
                 .withRetries(0)
                 .get()
                 .isEmpty();

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -85,9 +85,13 @@ public class AwsDiscoveryStrategyFactory
 
     private static boolean uuidWithEc2Prefix() {
         String uuidPath = "/sys/hypervisor/uuid";
-        if (new File(uuidPath).exists()) {
-            String uuid = readFileContents(uuidPath);
-            return uuid.startsWith("ec2") || uuid.startsWith("EC2");
+        try {
+            if (new File(uuidPath).exists()) {
+                String uuid = readFileContents(uuidPath);
+                return uuid.startsWith("ec2") || uuid.startsWith("EC2");
+            }
+        } catch (Exception e) {
+            LOGGER.finest(e);
         }
         return false;
     }
@@ -97,6 +101,7 @@ public class AwsDiscoveryStrategyFactory
             return isEndpointAvailable("http://169.254.169.254/latest/dynamic/instance-identity/");
         } catch (Exception e) {
             // any exception means that we're not running on AWS
+            LOGGER.finest(e);
             return false;
         }
     }
@@ -106,6 +111,7 @@ public class AwsDiscoveryStrategyFactory
             return isEndpointAvailable("http://169.254.169.254/latest/meta-data/iam/security-credentials/");
         } catch (Exception e) {
             LOGGER.warning("Hazelcast running on EC2 instance, but no IAM Role attached. Cannot use Hazelcast AWS discovery.");
+            LOGGER.finest(e);
             return false;
         }
     }

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -93,21 +93,11 @@ public class AwsDiscoveryStrategyFactory
     }
 
     private static boolean instanceIdentityExists() {
-        try {
-            return isEndpointAvailable("http://169.254.169.254/latest/dynamic/instance-identity/");
-        } catch (Exception e) {
-            // any exception means that we're not running on AWS
-            return false;
-        }
+        return isEndpointAvailable("http://169.254.169.254/latest/dynamic/instance-identity/");
     }
 
     private static boolean iamRoleAttached() {
-        try {
-            return isEndpointAvailable("http://169.254.169.254/latest/meta-data/iam/security-credentials/");
-        } catch (Exception e) {
-            LOGGER.warning("Hazelcast running on EC2 instance, but no IAM Role attached. Cannot use Hazelcast AWS discovery.");
-            return false;
-        }
+        return isEndpointAvailable("http://169.254.169.254/latest/meta-data/iam/security-credentials/");
     }
 
     static boolean isEndpointAvailable(String url) {
@@ -120,7 +110,7 @@ public class AwsDiscoveryStrategyFactory
                     .get()
                     .isEmpty();
         } catch (Exception e) {
-            // any exception means that connecting to the endpoint does not work
+            // any exception means that endpoint is not available
             return false;
         }
     }

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -67,11 +67,11 @@ public class AwsDiscoveryStrategyFactory
      * Hazelcast network interfaces (required for ECS).
      * <p>
      * To check if Hazelcast is running on EC2, we first check that the machine uuid starts with "ec2" or "EC2". There is
-     * a small chance that a non-AWS machine has uuid starting from the mentioned prefix. That is why, to be sure, we slo make
+     * a small chance that a non-AWS machine has uuid starting with the mentioned prefix. That is why, to be sure, we make
      * an API call to a local, non-routable address http://169.254.169.254/latest/dynamic/instance-identity/. Finally, we also
-     * check if the IAM Role is attached to the EC2 instance, because without any IAM Role the Hazelcast AWS discovery won't work.
+     * check if an IAM Role is attached to the EC2 instance, because without any IAM Role the Hazelcast AWS discovery won't work.
      *
-     * @return true if running in the AWS EC2 environment
+     * @return true if running on EC2 Instance which has an IAM Role attached
      * @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
      */
     @Override
@@ -129,7 +129,6 @@ public class AwsDiscoveryStrategyFactory
                 .withRetries(0)
                 .get()
                 .isEmpty();
-
     }
 
     private static boolean isRunningOnEcs() {

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -125,7 +125,7 @@ public class AwsDiscoveryStrategyFactory
         return !RestClient.create(url)
                 .withConnectTimeoutSeconds(1)
                 .withReadTimeoutSeconds(1)
-                .withRetries(0)
+                .withRetries(1)
                 .get()
                 .isEmpty();
     }

--- a/src/main/java/com/hazelcast/aws/NoCredentialsException.java
+++ b/src/main/java/com/hazelcast/aws/NoCredentialsException.java
@@ -15,23 +15,5 @@
 
 package com.hazelcast.aws;
 
-/**
- * Exception to indicate any issues while executing a REST call.
- */
-class RestClientException
-        extends RuntimeException {
-    private int httpErrorCode;
-
-    RestClientException(String message, int httpErrorCode) {
-        super(String.format("%s. HTTP Error Code: %s", message, httpErrorCode));
-        this.httpErrorCode = httpErrorCode;
-    }
-
-    RestClientException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    int getHttpErrorCode() {
-        return httpErrorCode;
-    }
+public class NoCredentialsException extends RuntimeException {
 }

--- a/src/main/java/com/hazelcast/aws/NoCredentialsException.java
+++ b/src/main/java/com/hazelcast/aws/NoCredentialsException.java
@@ -15,5 +15,8 @@
 
 package com.hazelcast.aws;
 
-public class NoCredentialsException extends RuntimeException {
+/**
+ * Exception to indicate that no credentials are possible to retrieve.
+ */
+class NoCredentialsException extends RuntimeException {
 }

--- a/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyFactoryTest.java
@@ -43,7 +43,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class AwsDiscoveryStrategyFactoryTest {
@@ -118,20 +117,6 @@ public class AwsDiscoveryStrategyFactoryTest {
 
         // then
         assertTrue(isAvailable);
-    }
-
-    @Test
-    public void isEndpointAvailableNotAvailable() {
-        // given
-        String endpoint = "/some-endpoint";
-        String url = String.format("http://localhost:%d%s", wireMockRule.port(), endpoint);
-        stubFor(get(urlEqualTo(endpoint)).willReturn(aResponse().withStatus(404).withBody("some-body")));
-
-        // when
-        boolean isAvailable = AwsDiscoveryStrategyFactory.isEndpointAvailable(url);
-
-        // then
-        assertFalse(isAvailable);
     }
 
     @Test

--- a/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyFactoryTest.java
@@ -15,22 +15,40 @@
 
 package com.hazelcast.aws;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
+import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class AwsDiscoveryStrategyFactoryTest {
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
     private static void createStrategy(Map<String, Comparable> props) {
         final AwsDiscoveryStrategyFactory factory = new AwsDiscoveryStrategyFactory();
@@ -86,5 +104,61 @@ public class AwsDiscoveryStrategyFactoryTest {
         assertTrue(strategies.hasNext());
         final DiscoveryStrategy strategy = strategies.next();
         assertTrue(strategy instanceof AwsDiscoveryStrategy);
+    }
+
+    @Test
+    public void isEndpointAvailable() {
+        // given
+        String endpoint = "/some-endpoint";
+        String url = String.format("http://localhost:%d%s", wireMockRule.port(), endpoint);
+        stubFor(get(urlEqualTo(endpoint)).willReturn(aResponse().withStatus(200).withBody("some-body")));
+
+        // when
+        boolean isAvailable = AwsDiscoveryStrategyFactory.isEndpointAvailable(url);
+
+        // then
+        assertTrue(isAvailable);
+    }
+
+    @Test
+    public void isEndpointAvailableNotAvailable() {
+        // given
+        String endpoint = "/some-endpoint";
+        String url = String.format("http://localhost:%d%s", wireMockRule.port(), endpoint);
+        stubFor(get(urlEqualTo(endpoint)).willReturn(aResponse().withStatus(404).withBody("some-body")));
+
+        // when
+        boolean isAvailable = AwsDiscoveryStrategyFactory.isEndpointAvailable(url);
+
+        // then
+        assertFalse(isAvailable);
+    }
+
+    @Test
+    public void readFileContents()
+            throws IOException {
+        // given
+        String expectedContents = "Hello, world!\nThis is a test with Unicode ✓.";
+        String testFile = createTestFile(expectedContents);
+
+        // when
+        String actualContents = AwsDiscoveryStrategyFactory.readFileContents(testFile);
+
+        // then
+        assertEquals(expectedContents, actualContents);
+    }
+
+    private static String createTestFile(String expectedContents)
+            throws IOException {
+        File temp = File.createTempFile("test", ".tmp");
+        temp.deleteOnExit();
+        BufferedWriter bufferedWriter = null;
+        try {
+            bufferedWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(temp), StandardCharsets.UTF_8));
+            bufferedWriter.write(expectedContents);
+        } finally {
+            IOUtil.closeResource(bufferedWriter);
+        }
+        return temp.getAbsolutePath();
     }
 }


### PR DESCRIPTION
Note that:
- We will need to release with the com.hazelcast:hazelcast:4.1-SNAPSHOT dependency
- This change is 100% backward-compatible (new released `hazelcast-aws` can be used with older hazelcast versions)
- Apart from auto-detection, the logs are improved
- Auto-detection won't work for ECS (since ECS anyway needs to have `interfaces` configured in the Hazelcast configuration)

-----------------------------------------------------------------------------

After this change, you can see the following logs while running on AWS EC2

1. Start on an EC2 instance without IAM Role assigned

```
Jul 29, 2020 2:23:58 PM com.hazelcast.aws.AwsDiscoveryStrategyFactory
WARNING: Hazelcast running on EC2 instance, but no IAM Role attached. Cannot use Hazelcast AWS discovery.
```
It starts with `MulticastJoiner`.

2. Start on EC2 Instance with IAM Role that misses the required permissions

```
Jul 29, 2020 2:25:03 PM com.hazelcast.aws.AwsDiscoveryStrategy
WARNING: AWS IAM Role Policy missing 'ec2:DescribeInstances' Action! Starting standalone.
```

It uses `AwsDiscoveryStrategyFactory`, but starts standalone, because does not have permissions required to discover other instances.

3. Start on EC2 Instance with correct IAM Role

Correctly discover all other EC2 machines in the same region.



