### PR TITLE
Increase verification time and use latest hazelcast-version

### DIFF
--- a/.github/terraform/scripts/verify_mancenter.sh
+++ b/.github/terraform/scripts/verify_mancenter.sh
@@ -6,7 +6,7 @@ EXPECTED_SIZE=$1
 
 verify_hazelcast_cluster_size() {
     EXPECTED_SIZE=$1
-    for i in `seq 1 5`; do
+    for i in `seq 1 6`; do
         local MEMBER_COUNT=$(cat ~/logs/mancenter.stdout.log | grep -E " Started communication with (a new )?member" | wc -l) 
 
         if [ "$MEMBER_COUNT" == "$EXPECTED_SIZE" ] ; then
@@ -14,7 +14,7 @@ verify_hazelcast_cluster_size() {
             return 0
         else
             echo "Hazelcast cluster size NOT equal to ${EXPECTED_SIZE}!. Waiting.."
-            sleep 5
+            sleep 10
         fi
     done
     return 1

--- a/.github/terraform/scripts/verify_member_count.sh
+++ b/.github/terraform/scripts/verify_member_count.sh
@@ -6,7 +6,7 @@ EXPECTED_SIZE=$1
 
 verify_hazelcast_cluster_size() {
     EXPECTED_SIZE=$1
-    for i in `seq 1 5`; do
+    for i in `seq 1 6`; do
         local MEMBER_COUNT=$( curl -sS http://127.0.0.1:5701/hazelcast/health/cluster-size )
 
         if [ "$MEMBER_COUNT" == "$EXPECTED_SIZE" ] ; then
@@ -14,7 +14,7 @@ verify_hazelcast_cluster_size() {
             return 0
         else
             echo "Hazelcast cluster size NOT equal to ${EXPECTED_SIZE}!. Waiting.."
-            sleep 5
+            sleep 10
         fi
     done
     return 1

--- a/.github/workflows/terraform-integration-tests.yml
+++ b/.github/workflows/terraform-integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
           if [[ $hz_version == *"SNAPSHOT"* ]]; then
             wo_SNAPSHOT=$( echo $hz_version | grep -Po "[.a-zA-Z0-9]+(?=-SNAPSHOT)" )
             snapshot_link=$(curl -s "https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast/$hz_version/" 2>&1 \
-                 | grep -Po  "hazelcast-$wo_SNAPSHOT-\d{8}.\d{6}-\d+\.jar" | head -1)
+                 | grep -Po  "hazelcast-$wo_SNAPSHOT-\d{8}.\d{6}-\d+\.jar" | tail -1)
             wget -q "https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast/$hz_version/$snapshot_link"
           else
             wget -q "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/$hz_version/hazelcast-$hz_version.jar"

--- a/.github/workflows/terraform-integration-tests.yml
+++ b/.github/workflows/terraform-integration-tests.yml
@@ -53,17 +53,15 @@ jobs:
       # DOWNLOAD HAZELCAST JAR WITH VERSION DEFINED IN POM.XML
       - name: Download latest Hazelcast version
         run: |
-          hz_version=$(cat hazelcast-aws/pom.xml | grep -m 1 -Po "<hazelcast.version>\K[-_.a-zA-Z0-9]+(?=</hazelcast.version)")
+          HZ_VERSION=$(cat hazelcast-aws/pom.xml | grep -m 1 -Po "<hazelcast.version>\K[-_.a-zA-Z0-9]+(?=</hazelcast.version)")
           if [[ $hz_version == *"SNAPSHOT"* ]]; then
-            wo_SNAPSHOT=$( echo $hz_version | grep -Po "[.a-zA-Z0-9]+(?=-SNAPSHOT)" )
-            snapshot_link=$(curl -s "https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast/$hz_version/" 2>&1 \
-                 | grep -Po  "hazelcast-$wo_SNAPSHOT-\d{8}.\d{6}-\d+\.jar" | tail -1)
-            wget -q "https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast/$hz_version/$snapshot_link"
+            export HZ_JAR_REPO_URL="https://oss.sonatype.org/content/repositories/snapshots"
           else
-            wget -q "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/$hz_version/hazelcast-$hz_version.jar"
+            export HZ_JAR_REPO_URL="https://repo1.maven.org/maven2"
           fi
-          echo "Hazelcast jar is: " hazelcast*.jar
-          cp hazelcast*.jar ~/lib/hazelcast.jar
+          mvn dependency:get -DgroupId=com.hazelcast -DartifactId=hazelcast -Dversion=${HZ_VERSION} \
+                  -Dpackaging=jar -DremoteRepositories=${HZ_JAR_REPO_URL}
+          cp ~/.m2/repository/com/hazelcast/hazelcast/${HZ_VERSION}/hazelcast-${HZ_VERSION}.jar ~/lib/hazelcast.jar
 
       #BUILD TERRAFORM
       - name : Set-up Terraform


### PR DESCRIPTION
Using latest hazelcast SNAPSHOT version also solves the error "write-error: Broken pipe". This error was not present until this day, but can be solved with using "tail" instead of "head".