### PR TITLE
Prevent fetching public addresses for ECS when not configured.

### DIFF
--- a/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -36,6 +36,7 @@ final class AwsConfig {
     private final int connectionRetries;
     private final int readTimeoutSeconds;
     private final PortRange hzPort;
+    private final boolean usePublicId;
     private final String accessKey;
     private final String secretKey;
     private final String iamRole;
@@ -47,8 +48,8 @@ final class AwsConfig {
     // Constructor has a lot of parameters, but it's private.
     private AwsConfig(String accessKey, String secretKey, String region, String iamRole, String hostHeader,
                       String securityGroupName, String tagKey, String tagValue, int connectionTimeoutSeconds,
-                      int connectionRetries, int readTimeoutSeconds, PortRange hzPort, String cluster, String family,
-                      String serviceName) {
+                      int connectionRetries, int readTimeoutSeconds, PortRange hzPort, boolean usePublicId,
+                      String cluster, String family, String serviceName) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.region = region;
@@ -61,6 +62,7 @@ final class AwsConfig {
         this.connectionRetries = connectionRetries;
         this.readTimeoutSeconds = readTimeoutSeconds;
         this.hzPort = hzPort;
+        this.usePublicId = usePublicId;
         this.cluster = cluster;
         this.family = family;
         this.serviceName = serviceName;
@@ -152,6 +154,10 @@ final class AwsConfig {
         return hzPort;
     }
 
+    boolean isUsePublicId() {
+        return usePublicId;
+    }
+
     String getCluster() {
         return cluster;
     }
@@ -176,6 +182,7 @@ final class AwsConfig {
             + ", tagKey='" + tagKey + '\''
             + ", tagValue='" + tagValue + '\''
             + ", hzPort=" + hzPort
+            + ", usePublicId=" + usePublicId
             + ", cluster='" + cluster + '\''
             + ", family='" + family + '\''
             + ", serviceName='" + serviceName + '\''
@@ -199,6 +206,7 @@ final class AwsConfig {
         private int connectionRetries;
         private int readTimeoutSeconds;
         private PortRange hzPort;
+        private boolean usePublicId;
         private String cluster;
         private String family;
         private String serviceName;
@@ -263,6 +271,11 @@ final class AwsConfig {
             return this;
         }
 
+        Builder setUsePublicId(boolean usePublicId) {
+            this.usePublicId = usePublicId;
+            return this;
+        }
+
         Builder setCluster(String cluster) {
             this.cluster = cluster;
             return this;
@@ -280,7 +293,8 @@ final class AwsConfig {
 
         AwsConfig build() {
             return new AwsConfig(accessKey, secretKey, region, iamRole, hostHeader, securityGroupName, tagKey, tagValue,
-                connectionTimeoutSeconds, connectionRetries, readTimeoutSeconds, hzPort, cluster, family, serviceName);
+                connectionTimeoutSeconds, connectionRetries, readTimeoutSeconds, hzPort, usePublicId, cluster, family,
+                    serviceName);
         }
     }
 }

--- a/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -36,7 +36,7 @@ final class AwsConfig {
     private final int connectionRetries;
     private final int readTimeoutSeconds;
     private final PortRange hzPort;
-    private final boolean usePublicId;
+    private final boolean usePublicIp;
     private final String accessKey;
     private final String secretKey;
     private final String iamRole;
@@ -48,7 +48,7 @@ final class AwsConfig {
     // Constructor has a lot of parameters, but it's private.
     private AwsConfig(String accessKey, String secretKey, String region, String iamRole, String hostHeader,
                       String securityGroupName, String tagKey, String tagValue, int connectionTimeoutSeconds,
-                      int connectionRetries, int readTimeoutSeconds, PortRange hzPort, boolean usePublicId,
+                      int connectionRetries, int readTimeoutSeconds, PortRange hzPort, boolean usePublicIp,
                       String cluster, String family, String serviceName) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
@@ -62,7 +62,7 @@ final class AwsConfig {
         this.connectionRetries = connectionRetries;
         this.readTimeoutSeconds = readTimeoutSeconds;
         this.hzPort = hzPort;
-        this.usePublicId = usePublicId;
+        this.usePublicIp = usePublicIp;
         this.cluster = cluster;
         this.family = family;
         this.serviceName = serviceName;
@@ -154,8 +154,8 @@ final class AwsConfig {
         return hzPort;
     }
 
-    boolean isUsePublicId() {
-        return usePublicId;
+    boolean isUsePublicIp() {
+        return usePublicIp;
     }
 
     String getCluster() {
@@ -182,7 +182,7 @@ final class AwsConfig {
             + ", tagKey='" + tagKey + '\''
             + ", tagValue='" + tagValue + '\''
             + ", hzPort=" + hzPort
-            + ", usePublicId=" + usePublicId
+            + ", usePublicIp=" + usePublicIp
             + ", cluster='" + cluster + '\''
             + ", family='" + family + '\''
             + ", serviceName='" + serviceName + '\''
@@ -206,7 +206,7 @@ final class AwsConfig {
         private int connectionRetries;
         private int readTimeoutSeconds;
         private PortRange hzPort;
-        private boolean usePublicId;
+        private boolean usePublicIp;
         private String cluster;
         private String family;
         private String serviceName;
@@ -271,8 +271,8 @@ final class AwsConfig {
             return this;
         }
 
-        Builder setUsePublicId(boolean usePublicId) {
-            this.usePublicId = usePublicId;
+        Builder setUsePublicIp(boolean usePublicIp) {
+            this.usePublicIp = usePublicIp;
             return this;
         }
 
@@ -293,7 +293,7 @@ final class AwsConfig {
 
         AwsConfig build() {
             return new AwsConfig(accessKey, secretKey, region, iamRole, hostHeader, securityGroupName, tagKey, tagValue,
-                connectionTimeoutSeconds, connectionRetries, readTimeoutSeconds, hzPort, usePublicId, cluster, family,
+                connectionTimeoutSeconds, connectionRetries, readTimeoutSeconds, hzPort, usePublicIp, cluster, family,
                     serviceName);
         }
     }

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -105,7 +105,7 @@ public class AwsDiscoveryStrategy
                 .setConnectionRetries(getOrDefault(CONNECTION_RETRIES.getDefinition(), DEFAULT_CONNECTION_RETRIES))
                 .setReadTimeoutSeconds(getOrDefault(READ_TIMEOUT_SECONDS.getDefinition(), DEFAULT_READ_TIMEOUT_SECONDS))
                 .setHzPort(new PortRange(getPortRange()))
-                .setUsePublicId(getOrDefault(USE_PUBLIC_IP.getDefinition(), DEFAULT_USE_PUBLIC_IP))
+                .setUsePublicIp(getOrDefault(USE_PUBLIC_IP.getDefinition(), DEFAULT_USE_PUBLIC_IP))
                 .setCluster(getOrNull(CLUSTER))
                 .setFamily(getOrNull(FAMILY))
                 .setServiceName(getOrNull(SERVICE_NAME))

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -46,6 +46,7 @@ import static com.hazelcast.aws.AwsProperties.SECURITY_GROUP_NAME;
 import static com.hazelcast.aws.AwsProperties.SERVICE_NAME;
 import static com.hazelcast.aws.AwsProperties.TAG_KEY;
 import static com.hazelcast.aws.AwsProperties.TAG_VALUE;
+import static com.hazelcast.aws.AwsProperties.USE_PUBLIC_IP;
 
 /**
  * AWS implementation of {@link DiscoveryStrategy}.
@@ -62,6 +63,7 @@ public class AwsDiscoveryStrategy
     private static final Integer DEFAULT_CONNECTION_RETRIES = 3;
     private static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10;
     private static final int DEFAULT_READ_TIMEOUT_SECONDS = 10;
+    private static final boolean DEFAULT_USE_PUBLIC_IP = false;
 
     private final AwsClient awsClient;
     private final PortRange portRange;
@@ -103,6 +105,7 @@ public class AwsDiscoveryStrategy
                 .setConnectionRetries(getOrDefault(CONNECTION_RETRIES.getDefinition(), DEFAULT_CONNECTION_RETRIES))
                 .setReadTimeoutSeconds(getOrDefault(READ_TIMEOUT_SECONDS.getDefinition(), DEFAULT_READ_TIMEOUT_SECONDS))
                 .setHzPort(new PortRange(getPortRange()))
+                .setUsePublicId(getOrDefault(USE_PUBLIC_IP.getDefinition(), DEFAULT_USE_PUBLIC_IP))
                 .setCluster(getOrNull(CLUSTER))
                 .setFamily(getOrNull(FAMILY))
                 .setServiceName(getOrNull(SERVICE_NAME))

--- a/src/main/java/com/hazelcast/aws/AwsEc2Api.java
+++ b/src/main/java/com/hazelcast/aws/AwsEc2Api.java
@@ -66,7 +66,7 @@ class AwsEc2Api {
     }
 
     boolean isUsePublicIp() {
-        return awsConfig.isUsePublicId();
+        return awsConfig.isUsePublicIp();
     }
 
     private Map<String, String> createAttributesDescribeInstances() {

--- a/src/main/java/com/hazelcast/aws/AwsEc2Api.java
+++ b/src/main/java/com/hazelcast/aws/AwsEc2Api.java
@@ -65,6 +65,10 @@ class AwsEc2Api {
         return parseDescribeInstances(response);
     }
 
+    boolean isUsePublicIp() {
+        return awsConfig.isUsePublicId();
+    }
+
     private Map<String, String> createAttributesDescribeInstances() {
         Map<String, String> attributes = createSharedAttributes();
         attributes.put("Action", "DescribeInstances");

--- a/src/main/java/com/hazelcast/aws/AwsProperties.java
+++ b/src/main/java/com/hazelcast/aws/AwsProperties.java
@@ -19,6 +19,7 @@ import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.PropertyTypeConverter;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
 
+import static com.hazelcast.config.properties.PropertyTypeConverter.BOOLEAN;
 import static com.hazelcast.config.properties.PropertyTypeConverter.INTEGER;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
@@ -101,6 +102,14 @@ enum AwsProperties {
      * The default value is "5701-5708".
      */
     PORT("hz-port", STRING, true),
+
+    /**
+     * If set to true, public addresses are preferred over private ones and used when establishing connection
+     * between instances.
+     * <p>
+     * The default value is false.
+     */
+    USE_PUBLIC_IP("use-public-ip", BOOLEAN, true),
 
     /**
      * ECS Cluster name or Cluster ARN.

--- a/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
@@ -38,6 +38,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -289,5 +290,21 @@ public class AwsEc2ApiTest {
         // then
         assertTrue(exception.getMessage().contains(Integer.toString(errorCode)));
         assertTrue(exception.getMessage().contains(errorMessage));
+    }
+
+    @Test
+    public void publicIpConfiguration() {
+        // default
+        assertFalse(awsEc2Api.isUsePublicIp());
+
+        // given
+        AwsConfig publicIpConfig = AwsConfig.builder().setUsePublicIp(true).build();
+        AwsConfig privateIpConfig = AwsConfig.builder().setUsePublicIp(false).build();
+        AwsEc2Api publicIpApi = new AwsEc2Api(null, publicIpConfig, null, null);
+        AwsEc2Api privateIpApi = new AwsEc2Api(null, privateIpConfig, null, null);
+
+        // then
+        assertTrue(publicIpApi.isUsePublicIp());
+        assertFalse(privateIpApi.isUsePublicIp());
     }
 }

--- a/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
@@ -67,13 +67,12 @@ public class AwsEcsClientTest {
         given(ecsMetadata.getClusterArn()).willReturn(CLUSTER);
         given(awsMetadataApi.metadataEcs()).willReturn(ecsMetadata);
         given(awsCredentialsProvider.credentials()).willReturn(CREDENTIALS);
-        given(awsEc2Api.isUsePublicIp()).willReturn(true);
 
         awsEcsClient = new AwsEcsClient(CLUSTER, awsEcsApi, awsEc2Api, awsMetadataApi, awsCredentialsProvider);
     }
 
     @Test
-    public void getAddresses() {
+    public void getAddressesUsingPublicIp() {
         // given
         List<String> taskArns = singletonList("task-arn");
         List<String> privateIps = singletonList("123.12.1.0");
@@ -82,6 +81,7 @@ public class AwsEcsClientTest {
         given(awsEcsApi.listTasks(CLUSTER, CREDENTIALS)).willReturn(taskArns);
         given(awsEcsApi.describeTasks(CLUSTER, taskArns, CREDENTIALS)).willReturn(tasks);
         given(awsEc2Api.describeNetworkInterfaces(privateIps, CREDENTIALS)).willReturn(expectedResult);
+        given(awsEc2Api.isUsePublicIp()).willReturn(true);
 
         // when
         Map<String, String> result = awsEcsClient.getAddresses();
@@ -91,7 +91,7 @@ public class AwsEcsClientTest {
     }
 
     @Test
-    public void getAddressesWithAwsConfig() {
+    public void getAddressesUsingPublicIpWithAwsConfig() {
         // given
         List<String> taskArns = singletonList("task-arn");
         List<String> privateIps = singletonList("123.12.1.0");
@@ -100,6 +100,7 @@ public class AwsEcsClientTest {
         given(awsEcsApi.listTasks(CLUSTER, CREDENTIALS)).willReturn(taskArns);
         given(awsEcsApi.describeTasks(CLUSTER, taskArns, CREDENTIALS)).willReturn(tasks);
         given(awsEc2Api.describeNetworkInterfaces(privateIps, CREDENTIALS)).willReturn(expectedResult);
+        given(awsEc2Api.isUsePublicIp()).willReturn(true);
 
         // when
         Map<String, String> result = awsEcsClient.getAddresses();
@@ -109,7 +110,7 @@ public class AwsEcsClientTest {
     }
 
     @Test
-    public void usePrivateAddressesOnly() {
+    public void getAddressesUsingPrivateIp() {
         // given
         List<String> taskArns = singletonList("task-arn");
         List<String> privateIps = singletonList("123.12.1.0");


### PR DESCRIPTION
Fixes #210 

Also, I'm not sure whether the same check is required or not for EC2 client also. Regarding the permissions, I don't think it will be a problem as `ec2:describeInstances` should already be attached and this also supplies public ip info. However if a user prefers private ones over public or public addresses are not associated at all, then this might be the case for EC2. 