### PR TITLE
Add PLACEMENT_AWARE partition group support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,12 +334,34 @@ these groups based on the network interfaces of members. See more details on cus
 ### Multi-Zone Deployments
 
 If `ZONE_AWARE` partition group is enabled, the backup(s) of a partition is always stored in a different availability
-zone - as long as there exists at least one member in a different zone. Hazelcast AWS Discovery plugin supports
-ZONE_AWARE feature for both EC2 and ECS.
+zone. Hazelcast AWS Discovery plugin supports ZONE_AWARE feature for both EC2 and ECS.
 
 ***NOTE:*** *When using the `ZONE_AWARE` partition grouping, a cluster spanning multiple Availability Zones (AZ)
 should have an equal number of members in each AZ. Otherwise, it will result in uneven partition distribution among
 the members.*
+
+#### XML Configuration
+
+```xml
+<partition-group enabled="true" group-type="ZONE_AWARE" />
+```
+
+#### YAML Configuration
+
+```yaml
+hazelcast:
+  partition-group:
+    enabled: true
+    group-type: ZONE_AWARE
+```
+
+#### Java-based Configuration
+
+```java
+config.getPartitionGroupConfig()
+    .setEnabled(true)
+    .setGroupType(MemberGroupType.ZONE_AWARE);
+```
 
 ### Partition Placement Group Deployments
 
@@ -374,13 +396,13 @@ limited to 7 instances, so if you need a larger Hazelcast cluster within a singl
 ***NOTE:*** *In the case of SPG, using `PLACEMENT_AWARE` has no effect, so can use the default Hazelcast partition group
 strategy.*
 
-### XML Configuration
+#### XML Configuration
 
 ```xml
-<partition-group enabled="true" group-type="ZONE_AWARE" />
+<partition-group enabled="true" group-type="PLACEMENT_AWARE" />
 ```
 
-### YAML Configuration
+#### YAML Configuration
 
 ```yaml
 hazelcast:
@@ -389,7 +411,7 @@ hazelcast:
     group-type: PLACEMENT_AWARE
 ```
 
-### Java-based Configuration
+#### Java-based Configuration
 
 ```java
 config.getPartitionGroupConfig()

--- a/README.md
+++ b/README.md
@@ -350,9 +350,9 @@ PPG contain an equal number of instances, it will be good practice for Hazelcast
 
 If EC2 instances belong to a PPG and `PLACEMENT_AWARE` partition group is enabled, then Hazelcast members will be grouped
 by the partitions of the PPG. For instance, the Hazelcast members in the first partition of a PPG named `ppg` will belong
-to the partition group of `ppg@1`, and those in the second partition will belong to `ppg@2` and so on. Furthermore, these
-groups will be specific to each availability zone. That is, they are formed with zone names as well: `us-east-1-ppg@1`,
-`us-east-2-ppg@1`, and the like. However, if a Hazelcast cluster spans multiple availability zones then you should
+to the partition group of `ppg-1`, and those in the second partition will belong to `ppg-2` and so on. Furthermore, these
+groups will be specific to each availability zone. That is, they are formed with zone names as well: `us-east-1-ppg-1`,
+`us-east-2-ppg-1`, and the like. However, if a Hazelcast cluster spans multiple availability zones then you should
 consider using `ZONE_AWARE`.
 
 ### Cluster Placement Group Deployments

--- a/README.md
+++ b/README.md
@@ -333,10 +333,9 @@ these groups based on the network interfaces of members. See more details on cus
 
 ### Zone Aware
 
-If `ZONE_AWARE` partition group is enabled, the backup(s) of a partition will be in a different availability zone
-other than the partition's residing zone. If no other partition group is found in other zones, the backup(s) will
-be stored in the same zone as the partition itself. Hazelcast AWS Discovery plugin supports ZONE_AWARE feature for
-both EC2 and ECS.
+If `ZONE_AWARE` partition group is enabled, the backup(s) of a partition is always stored in a different availability
+zone - as long as there exists at least one member in a different zone. Hazelcast AWS Discovery plugin supports
+ZONE_AWARE feature for both EC2 and ECS.
 
 #### XML Configuration
 
@@ -377,8 +376,8 @@ especially for the clusters formed within a single availability zone. `PLACEMENT
 If EC2 instances belong to a PPG, then Hazelcast members will be grouped by the partitions of the PPG. For instance,
 the Hazelcast members in the first partition of a PPG named `ppg` will belong to the partition group of `ppg@1`,
 and those in the second partition will belong to `ppg@2` and so on. Furthermore, these groups will be specific to each
-availability zone. That is, they are formed with zone names as well: `us-east-1-ppg@1`, `us-east-2-ppg@1`, etc. Hence,
-if a PPG spans multiple availability zones then PLACEMENT_AWARE can still form partition groups.   
+availability zone. That is, they are formed with zone names as well: `us-east-1-ppg@1`, `us-east-2-ppg@1`, and the like.
+However, if a Hazelcast cluster spans multiple availability zones then you should consider using `ZONE_AWARE`.
  
 PPG ensures low latency between the members in the same partition of a placement group and also provides availability by
 storing replicas in other partitions of the placement. As long as the partitions of a PPG contain an equal number of

--- a/README.md
+++ b/README.md
@@ -320,12 +320,9 @@ The plugin works correctly on the AWS Elastic Beanstalk environment. While deplo
 
 ## High Availability
 
-By default, Hazelcast distributes partition replicas (backups) randomly and equally among the cluster members, assuming
-all the members in a cluster are identical. However, this is not safe in terms of availability when a partition and its
-replicas are stored on the same rack, using the same network or power source, etc. To deal with that, Hazelcast offers
-partition groups each is a logical grouping of members. If there is enough number of partition groups, a partition
-itself and its backup(s) are not stored within the same group. This way Hazelcast guarantees that a possible failure
-affecting more than one member at a time will not cause data loss. The details of partition groups can be found on the
+By default, Hazelcast distributes partition replicas (backups) randomly and equally among cluster members. However, this is not safe in terms of high availability when a partition and its replicas are stored on the same rack, using the same network, or power source. To deal with that, Hazelcast offers logical partition grouping, so that a partition
+itself and its backup(s) would not be stored within the same group. This way Hazelcast guarantees that a possible failure
+affecting more than one member at a time will not cause data loss. The details of partition groups can be found in the
 documentation: 
 [Partition Group Configuration](https://docs.hazelcast.org/docs/latest/manual/html-single/#partition-group-configuration)
 
@@ -389,18 +386,9 @@ instances, it will be good practice for Hazelcast clusters formed within a singl
 
 #### Spread Placement Group (SPG)
 
-SPG ensures availability by placing each instance in a group on a distinct rack. This way, it ensures availability
-within a single zone. If a Hazelcast cluster is deployed with the default partition group strategy - which assumes each
-member as a separate group, then this will be an appropriate configuration for the scenario where all instances belong to
-a single SPG. If PLACEMENT_AWARE is enabled for a cluster under an SPG named `spg`, this will end up with a single 
-partition group where all members belong to the same group (e.g. `us-east-1-spg`) - which will also have the same
-logic as the default strategy. 
+SPG ensures high availability in a single zone by placing each instance in a group on a distinct rack. It provides better latency than multi-zone deployment, but worse than Cluster Placement Group. SPG is limited to 7 instances, so if you need a bigger Hazelcast cluster, you should use PPG instead.
 
-Forming a Hazelcast cluster within a single zone using the default partition group strategy and the instances in an SPG
-will be good practice. However, SPG has a limitation of having at most 7 instances per zone. If you need more than 7
-instances within a zone and want to ensure availability as much as possible, then consider using PPG. Another alternative
-could be using more than one SPG. However, this action needs to be taken with care. Because two instances from different
-SPGs can share the same rack - although they belong to different partition groups.
+Note: In the case of SPG, using `PLACEMENT_AWARE` has no effect, so can leave the default Hazelcast Partition Group configuration.
 
 #### Cluster Placement Group (CPG)
 

--- a/README.md
+++ b/README.md
@@ -327,89 +327,60 @@ documentation:
 [Partition Group Configuration](https://docs.hazelcast.org/docs/latest/manual/html-single/#partition-group-configuration)
 
 In addition to two built-in grouping options `ZONE_AWARE` and `PLACEMENT_AWARE`, you can customize the formation of
-these groups based on the network interfaces of members. See more details on custom groups on the documentation:
+these groups based on the network interfaces of members. See more details on custom groups in the documentation:
 [Custom Partition Groups](https://docs.hazelcast.org/docs/latest/manual/html-single/#custom).
 
 
-### Zone Aware
+### Multi-Zone Deployments
 
 If `ZONE_AWARE` partition group is enabled, the backup(s) of a partition is always stored in a different availability
 zone - as long as there exists at least one member in a different zone. Hazelcast AWS Discovery plugin supports
 ZONE_AWARE feature for both EC2 and ECS.
 
-#### XML Configuration
+***NOTE:*** *When using the `ZONE_AWARE` partition grouping, a cluster spanning multiple Availability Zones (AZ)
+should have an equal number of members in each AZ. Otherwise, it will result in uneven partition distribution among
+the members.*
+
+### Partition Placement Group Deployments
+
+[AWS Partition Placement Group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-partition)
+(PPG) ensures low latency between the instances in the same partition of a placement group
+and also provides availability since no two partitions share the same underlying hardware. As long as the partitions of a 
+PPG contain an equal number of instances, it will be good practice for Hazelcast clusters formed within a single zone.
+
+If EC2 instances belong to a PPG and `PLACEMENT_AWARE` partition group is enabled, then Hazelcast members will be grouped
+by the partitions of the PPG. For instance, the Hazelcast members in the first partition of a PPG named `ppg` will belong
+to the partition group of `ppg@1`, and those in the second partition will belong to `ppg@2` and so on. Furthermore, these
+groups will be specific to each availability zone. That is, they are formed with zone names as well: `us-east-1-ppg@1`,
+`us-east-2-ppg@1`, and the like. However, if a Hazelcast cluster spans multiple availability zones then you should
+consider using `ZONE_AWARE`.
+
+### Cluster Placement Group Deployments
+
+[AWS Cluster Placement Group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-cluster)
+(CPG) ensures low latency by packing instances close together inside an availability zone.
+If you favor latency over availability, then CPG will serve your purpose.
+
+***NOTE:*** *In the case of CPG, using `PLACEMENT_AWARE` has no effect, so can use the default Hazelcast partition group
+strategy.*
+
+### Spread Placement Group Deployments
+
+[AWS Spread Placement Groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-spread)
+(SPG) ensures high availability in a single zone by placing each instance in a group on a
+distinct rack. It provides better latency than multi-zone deployment, but worse than Cluster Placement Group. SPG is
+limited to 7 instances, so if you need a larger Hazelcast cluster within a single zone, you should use PPG instead.
+
+***NOTE:*** *In the case of SPG, using `PLACEMENT_AWARE` has no effect, so can use the default Hazelcast partition group
+strategy.*
+
+### XML Configuration
 
 ```xml
 <partition-group enabled="true" group-type="ZONE_AWARE" />
 ```
 
-#### YAML Configuration
-
-```yaml
-hazelcast:
-  partition-group:
-    enabled: true
-    group-type: ZONE-AWARE
-```
-
-#### Java-based Configuration
-
-```java
-config.getPartitionGroupConfig()
-    .setEnabled(true)
-    .setGroupType(MemberGroupType.ZONE_AWARE);
-```
-
-***NOTE:*** *When using the `ZONE_AWARE` partition grouping, a cluster spanning multiple Availability Zones (AZ)
-should have an equal number of members in each AZ. Otherwise, it will result in uneven partition distribution among
-the members.*
-
-### Placement Aware
-
-If EC2 instances belong to an [AWS Placement Group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html),
-then Hazelcast can form partition groups based on the placement groups of the instances. The backup(s) of a partition
-will be in a different placement group other than the partition's placement group. The strategy ensures availability
-especially for the clusters formed within a single availability zone. `PLACEMENT_AWARE` is not supported for ECS.
-
-#### Partition Placement Group (PPG)
-
-If EC2 instances belong to a PPG, then Hazelcast members will be grouped by the partitions of the PPG. For instance,
-the Hazelcast members in the first partition of a PPG named `ppg` will belong to the partition group of `ppg@1`,
-and those in the second partition will belong to `ppg@2` and so on. Furthermore, these groups will be specific to each
-availability zone. That is, they are formed with zone names as well: `us-east-1-ppg@1`, `us-east-2-ppg@1`, and the like.
-However, if a Hazelcast cluster spans multiple availability zones then you should consider using `ZONE_AWARE`.
- 
-PPG ensures low latency between the members in the same partition of a placement group and also provides availability by
-storing replicas in other partitions of the placement. As long as the partitions of a PPG contain an equal number of
-instances, it will be good practice for Hazelcast clusters formed within a single zone.
-
-#### Spread Placement Group (SPG)
-
-SPG ensures high availability in a single zone by placing each instance in a group on a distinct rack. It provides better latency than multi-zone deployment, but worse than Cluster Placement Group. SPG is limited to 7 instances, so if you need a bigger Hazelcast cluster, you should use PPG instead.
-
-Note: In the case of SPG, using `PLACEMENT_AWARE` has no effect, so can leave the default Hazelcast Partition Group configuration.
-
-#### Cluster Placement Group (CPG)
-
-CPG ensures low latency by packing instances close together inside an availability zone. If you favor latency over
-availability, then CPG will serve your purpose. When deploying a Hazelcast cluster to the instances of a single CPG,
-partition group strategy should not be a concern as you favor latency. Even if you enable PLACEMENT_AWARE for the instances
-of a CFG named `cpg`, this will end up with a single partition group where all members belong to the same group 
-(e.g. `us-east-1-cpg`) - which will also have the same logic as the default strategy. 
-
-If you use more than one CPG - say `cpg1` and `cpg2`, for the instances within the same zone, the PLACEMENT_AWARE strategy 
-will group the instances as `us-east-1-cpg1` and `us-east-1-cpg2`. This is somehow reasonable in terms of availability.
-However, it might not be guaranteed that `cpg1` and `cpg2` won't share the same rack. Thus, PPG would fit better in this
-case. If you use more than one CPG from different zones, this time ZONE_AWARE would be a better alternative to 
-PLACEMENT_AWARE as it will pack all the instances within a single zone into the same partition group.
-
-#### XML Configuration
-
-```xml
-<partition-group enabled="true" group-type="PLACEMENT_AWARE" />
-```
-
-#### YAML Configuration
+### YAML Configuration
 
 ```yaml
 hazelcast:
@@ -418,22 +389,13 @@ hazelcast:
     group-type: PLACEMENT_AWARE
 ```
 
-#### Java-based Configuration
+### Java-based Configuration
 
 ```java
 config.getPartitionGroupConfig()
     .setEnabled(true)
     .setGroupType(MemberGroupType.PLACEMENT_AWARE);
 ```
-
-***NOTE:*** *When using the `PLACEMENT_AWARE` partition grouping, a cluster spanning multiple Placement Groups (PG)
-should have an equal number of members in each PG (and in each partition if the placement group is PPG). Otherwise,
-it will result in uneven partition distribution among the members.*
-
-***NOTE:*** *When using the `PLACEMENT_AWARE` with Cluster Placement Groups or Spread Placement Groups, remember 
-that there will be only one partition group per placement group. So, favor Partition Placement Groups with Hazelcast
-clusters formed within a single zone. If you use other placement groups with `PLACEMENT_AWARE` set up your placements
-with care to have reasonable partition groups.*
 
 ## Autoscaling
 

--- a/src/main/java/com/hazelcast/aws/AwsClient.java
+++ b/src/main/java/com/hazelcast/aws/AwsClient.java
@@ -16,6 +16,7 @@
 package com.hazelcast.aws;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Responsible for fetching discovery information from AWS APIs.
@@ -24,4 +25,22 @@ interface AwsClient {
     Map<String, String> getAddresses();
 
     String getAvailabilityZone();
+
+    /**
+     * Returns the placement group name of the service if specified.
+     *
+     * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html">Placement Groups</a>
+     */
+    default Optional<String> getPlacementGroup() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the partition number of the service if it belongs to a partition placement group.
+     *
+     * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-partition">Partition Placement Groups</a>
+     */
+    default Optional<String> getPlacementPartitionNumber() {
+        return Optional.empty();
+    }
 }

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.hazelcast.aws.AwsProperties.ACCESS_KEY;
 import static com.hazelcast.aws.AwsProperties.CLUSTER;
@@ -62,6 +63,9 @@ public class AwsDiscoveryStrategy
     private static final Integer DEFAULT_CONNECTION_RETRIES = 3;
     private static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10;
     private static final int DEFAULT_READ_TIMEOUT_SECONDS = 10;
+
+    // TODO: To be replaced with PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT
+    static final String PARTITION_GROUP_PLACEMENT = "hazelcast.partition.group.placement";
 
     private final AwsClient awsClient;
     private final PortRange portRange;
@@ -132,8 +136,38 @@ public class AwsDiscoveryStrategy
             String availabilityZone = awsClient.getAvailabilityZone();
             LOGGER.info(String.format("Availability zone found: '%s'", availabilityZone));
             memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_ZONE, availabilityZone);
+
+            getPlacementGroup().ifPresent(pg ->
+                    memberMetadata.put(PARTITION_GROUP_PLACEMENT, availabilityZone + '-' + pg));
         }
         return memberMetadata;
+    }
+
+    /**
+     * Resolves the placement group of the resource if it belongs to any.
+     * <p>
+     * If the placement group is Cluster Placement Group or Spread Placement Group, then returns
+     * the group name. If it is Partition Placement Group, then returns the group name with the
+     * partition number prefixed by '@' appended.
+     * <p>
+     * When forming partition groups, this name should be combined with zone name. Otherwise
+     * two resources in different zones but in the same placement group will be assumed as
+     * a single group.
+     *
+     * @see AwsClient#getPlacementGroup()
+     * @see AwsClient#getPlacementPartitionNumber()
+     * @return  Placement group name if exists, empty otherwise.
+     */
+    private Optional<String> getPlacementGroup() {
+        Optional<String> placementGroup = awsClient.getPlacementGroup();
+        if (!placementGroup.isPresent()) {
+            LOGGER.fine("No placement group is found.");
+            return Optional.empty();
+        }
+        StringBuilder result = new StringBuilder(placementGroup.get());
+        awsClient.getPlacementPartitionNumber().ifPresent(ppn -> result.append('@').append(ppn));
+        LOGGER.info(String.format("Placement group found: '%s'", result.toString()));
+        return Optional.of(result.toString());
     }
 
     @Override

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -148,7 +148,7 @@ public class AwsDiscoveryStrategy
      * <p>
      * If the placement group is Cluster Placement Group or Spread Placement Group, then returns
      * the group name. If it is Partition Placement Group, then returns the group name with the
-     * partition number prefixed by {@code '@'} appended.
+     * partition number prefixed by '-' appended.
      * <p>
      * When forming partition groups, this name should be combined with zone name. Otherwise
      * two resources in different zones but in the same placement group will be assumed as
@@ -165,7 +165,7 @@ public class AwsDiscoveryStrategy
             return Optional.empty();
         }
         StringBuilder result = new StringBuilder(placementGroup.get());
-        awsClient.getPlacementPartitionNumber().ifPresent(ppn -> result.append('@').append(ppn));
+        awsClient.getPlacementPartitionNumber().ifPresent(ppn -> result.append('-').append(ppn));
         LOGGER.info(String.format("Placement group found: '%s'", result.toString()));
         return Optional.of(result.toString());
     }

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -64,7 +64,7 @@ public class AwsDiscoveryStrategy
     private static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10;
     private static final int DEFAULT_READ_TIMEOUT_SECONDS = 10;
 
-    // TODO: To be replaced with PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT
+    // Corresponds to PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT
     static final String PARTITION_GROUP_PLACEMENT = "hazelcast.partition.group.placement";
 
     private final AwsClient awsClient;

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -148,7 +148,7 @@ public class AwsDiscoveryStrategy
      * <p>
      * If the placement group is Cluster Placement Group or Spread Placement Group, then returns
      * the group name. If it is Partition Placement Group, then returns the group name with the
-     * partition number prefixed by '@' appended.
+     * partition number prefixed by {@code '@'} appended.
      * <p>
      * When forming partition groups, this name should be combined with zone name. Otherwise
      * two resources in different zones but in the same placement group will be assumed as

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -127,6 +127,7 @@ public class AwsDiscoveryStrategyFactory
                 .withReadTimeoutSeconds(1)
                 .withRetries(1)
                 .get()
+                .getBody()
                 .isEmpty();
     }
 

--- a/src/main/java/com/hazelcast/aws/AwsEc2Api.java
+++ b/src/main/java/com/hazelcast/aws/AwsEc2Api.java
@@ -203,7 +203,8 @@ class AwsEc2Api {
         String query = canonicalQueryString(attributes);
         return createRestClient(urlFor(endpoint, query), awsConfig)
             .withHeaders(headers)
-            .get();
+            .get()
+            .getBody();
     }
 
     private static String urlFor(String endpoint, String query) {

--- a/src/main/java/com/hazelcast/aws/AwsEc2Client.java
+++ b/src/main/java/com/hazelcast/aws/AwsEc2Client.java
@@ -16,6 +16,7 @@
 package com.hazelcast.aws;
 
 import java.util.Map;
+import java.util.Optional;
 
 class AwsEc2Client implements AwsClient {
     private final AwsEc2Api awsEc2Api;
@@ -36,5 +37,15 @@ class AwsEc2Client implements AwsClient {
     @Override
     public String getAvailabilityZone() {
         return awsMetadataApi.availabilityZoneEc2();
+    }
+
+    @Override
+    public Optional<String> getPlacementGroup() {
+        return awsMetadataApi.placementGroupEc2();
+    }
+
+    @Override
+    public Optional<String> getPlacementPartitionNumber() {
+        return awsMetadataApi.placementPartitionNumberEc2();
     }
 }

--- a/src/main/java/com/hazelcast/aws/AwsEcsApi.java
+++ b/src/main/java/com/hazelcast/aws/AwsEcsApi.java
@@ -138,7 +138,8 @@ class AwsEcsApi {
         return createRestClient(urlFor(endpoint), awsConfig)
             .withHeaders(headers)
             .withBody(body)
-            .post();
+            .post()
+            .getBody();
     }
 
     private static JsonObject toJson(String jsonString) {

--- a/src/main/java/com/hazelcast/aws/AwsMetadataApi.java
+++ b/src/main/java/com/hazelcast/aws/AwsMetadataApi.java
@@ -106,8 +106,7 @@ class AwsMetadataApi {
             LOGGER.fine(String.format("No %s information is found.", loggedName));
             return Optional.empty();
         } else {
-            throw new RuntimeException(String.format("Unexpected response code: %d"
-                    + " which must be handled by the rest client.", responseCode));
+            throw new RuntimeException(String.format("Unexpected response code: %d", responseCode));
         }
     }
 

--- a/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
@@ -49,7 +49,7 @@ public class AwsDiscoveryStrategyTest {
     // Group name pattern for placement groups
     private static final String PG_NAME_PATTERN = "%s-%s";
     // Group name pattern for partition placement group
-    private static final String PPG_NAME_PATTERN = PG_NAME_PATTERN.concat("@%s");
+    private static final String PPG_NAME_PATTERN = PG_NAME_PATTERN.concat("-%s");
 
     @Mock
     private AwsClient awsClient;

--- a/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.hazelcast.spi.partitiongroup.PartitionGroupMetaData.PARTITION_GROUP_ZONE;
 import static java.util.Collections.emptyList;
@@ -42,6 +43,13 @@ public class AwsDiscoveryStrategyTest {
     private static final int PORT1 = 5701;
     private static final int PORT2 = 5702;
     private static final String ZONE = "us-east-1a";
+    private static final String PLACEMENT_GROUP = "placement-group";
+    private static final String PLACEMENT_PARTITION_ID = "42";
+
+    // Group name pattern for placement groups
+    private static final String PG_NAME_PATTERN = "%s-%s";
+    // Group name pattern for partition placement group
+    private static final String PPG_NAME_PATTERN = PG_NAME_PATTERN.concat("@%s");
 
     @Mock
     private AwsClient awsClient;
@@ -125,15 +133,52 @@ public class AwsDiscoveryStrategyTest {
     }
 
     @Test
-    public void discoverLocalMetadata() {
+    public void discoverLocalMetadataWithoutPlacement() {
         // given
         given(awsClient.getAvailabilityZone()).willReturn(ZONE);
+        given(awsClient.getPlacementGroup()).willReturn(Optional.empty());
+        given(awsClient.getPlacementPartitionNumber()).willReturn(Optional.empty());
 
         // when
         Map<String, String> localMetaData = awsDiscoveryStrategy.discoverLocalMetadata();
 
         // then
+        assertEquals(1, localMetaData.size());
         assertEquals(ZONE, localMetaData.get(PARTITION_GROUP_ZONE));
+    }
+
+    @Test
+    public void discoverLocalMetadataWithPlacement() {
+        // given
+        given(awsClient.getAvailabilityZone()).willReturn(ZONE);
+        given(awsClient.getPlacementGroup()).willReturn(Optional.of(PLACEMENT_GROUP));
+        given(awsClient.getPlacementPartitionNumber()).willReturn(Optional.empty());
+        String expectedPartitionGroup = String.format(PG_NAME_PATTERN, ZONE, PLACEMENT_GROUP);
+
+        // when
+        Map<String, String> localMetaData = awsDiscoveryStrategy.discoverLocalMetadata();
+
+        // then
+        assertEquals(2, localMetaData.size());
+        assertEquals(ZONE, localMetaData.get(PARTITION_GROUP_ZONE));
+        assertEquals(expectedPartitionGroup, localMetaData.get(AwsDiscoveryStrategy.PARTITION_GROUP_PLACEMENT));
+    }
+
+    @Test
+    public void discoverLocalMetadataWithPartitionPlacement() {
+        // given
+        given(awsClient.getAvailabilityZone()).willReturn(ZONE);
+        given(awsClient.getPlacementGroup()).willReturn(Optional.of(PLACEMENT_GROUP));
+        given(awsClient.getPlacementPartitionNumber()).willReturn(Optional.of(PLACEMENT_PARTITION_ID));
+        String expectedPartitionGroup = String.format(PPG_NAME_PATTERN, ZONE, PLACEMENT_GROUP, PLACEMENT_PARTITION_ID);
+
+        // when
+        Map<String, String> localMetaData = awsDiscoveryStrategy.discoverLocalMetadata();
+
+        // then
+        assertEquals(2, localMetaData.size());
+        assertEquals(ZONE, localMetaData.get(PARTITION_GROUP_ZONE));
+        assertEquals(expectedPartitionGroup, localMetaData.get(AwsDiscoveryStrategy.PARTITION_GROUP_PLACEMENT));
     }
 
     @Test

--- a/src/test/java/com/hazelcast/aws/AwsEc2ClientTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsEc2ClientTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
@@ -72,5 +73,22 @@ public class AwsEc2ClientTest {
 
         // then
         assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void getPlacementGroup() {
+        // given
+        String placementGroup = "placement-group";
+        String partitionNumber = "42";
+        given(awsMetadataApi.placementGroupEc2()).willReturn(Optional.of(placementGroup));
+        given(awsMetadataApi.placementPartitionNumberEc2()).willReturn(Optional.of(partitionNumber));
+
+        // when
+        Optional<String> placementGroupResult = awsEc2Client.getPlacementGroup();
+        Optional<String> partitionNumberResult = awsEc2Client.getPlacementPartitionNumber();
+
+        // then
+        assertEquals(placementGroup, placementGroupResult.orElse("N/A"));
+        assertEquals(partitionNumber, partitionNumberResult.orElse("N/A"));
     }
 }

--- a/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
@@ -25,6 +25,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -159,5 +160,17 @@ public class AwsEcsClientTest {
 
         // then
         assertEquals("unknown", result);
+    }
+
+    @Test
+    public void getPlacementGroup() {
+        // when
+        Optional<String> placementGroup = awsEcsClient.getPlacementGroup();
+        Optional<String> placementPartitionNumber = awsEcsClient.getPlacementPartitionNumber();
+
+        // then
+        // Placement aware is not supported for ECS
+        assertEquals(Optional.empty(), placementGroup);
+        assertEquals(Optional.empty(), placementPartitionNumber);
     }
 }

--- a/src/test/java/com/hazelcast/aws/AwsMetadataApiTest.java
+++ b/src/test/java/com/hazelcast/aws/AwsMetadataApiTest.java
@@ -21,6 +21,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -57,6 +59,51 @@ public class AwsMetadataApiTest {
 
         // then
         assertEquals(availabilityZone, result);
+    }
+
+    @Test
+    public void placementGroupEc2() {
+        // given
+        String placementGroup = "placement-group-1";
+        stubFor(get(urlEqualTo("/placement/group-name/"))
+                .willReturn(aResponse().withStatus(200).withBody(placementGroup)));
+
+        // when
+        Optional<String> result = awsMetadataApi.placementGroupEc2();
+
+        // then
+        assertEquals(placementGroup, result.orElse("N/A"));
+    }
+
+    @Test
+    public void partitionPlacementGroupEc2() {
+        // given
+        String partitionNumber = "42";
+        stubFor(get(urlEqualTo("/placement/partition-number/"))
+                .willReturn(aResponse().withStatus(200).withBody(partitionNumber)));
+
+        // when
+        Optional<String> result = awsMetadataApi.placementPartitionNumberEc2();
+
+        // then
+        assertEquals(partitionNumber, result.orElse("N/A"));
+    }
+
+    @Test
+    public void missingPlacementGroupEc2() {
+        // given
+        stubFor(get(urlEqualTo("/placement/group-name/"))
+                .willReturn(aResponse().withStatus(404).withBody("Not found")));
+        stubFor(get(urlEqualTo("/placement/partition-number/"))
+                .willReturn(aResponse().withStatus(404).withBody("Not found")));
+
+        // when
+        Optional<String> placementGroupResult = awsMetadataApi.placementGroupEc2();
+        Optional<String> partitionNumberResult = awsMetadataApi.placementPartitionNumberEc2();
+
+        // then
+        assertEquals(Optional.empty(), placementGroupResult);
+        assertEquals(Optional.empty(), partitionNumberResult);
     }
 
     @Test


### PR DESCRIPTION
Adds placement aware partition group strategy support to form partition groups based on AWS placement groups. The strategy provides availability within a single zone as high as possible by spreading partitions and their replicas across different racks. 

- Related [PRD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1110868589/Support+for+AWS+Placement+Groups) 
- Related [TDD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/2954363031/Support+for+AWS+Placement+Groups+-+TDD) 
- Core: https://github.com/hazelcast/hazelcast/pull/18048