### PR TITLE
Change logResult to only log once

### DIFF
--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -208,9 +208,10 @@ public class AwsDiscoveryStrategy
         return Collections.emptyList();
     }
 
-    private static void logResult(Map<String, String> addresses) {
-        if (addresses.isEmpty()) {
+    private void logResult(Map<String, String> addresses) {
+        if (addresses.isEmpty() && !isKnownExceptionAlreadyLogged) {
             LOGGER.warning("No IP addresses found! Starting standalone.");
+            isKnownExceptionAlreadyLogged = true;
         }
 
         LOGGER.fine(String.format("Found the following (private => public) addresses: %s", addresses));

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -73,6 +73,7 @@ public class AwsDiscoveryStrategy
     private final Map<String, String> memberMetadata = new HashMap<>();
 
     private boolean isKnownExceptionAlreadyLogged;
+    private boolean isEmptyAddressListAlreadyLogged;
 
     AwsDiscoveryStrategy(Map<String, Comparable> properties) {
         super(LOGGER, properties);
@@ -209,9 +210,9 @@ public class AwsDiscoveryStrategy
     }
 
     private void logResult(Map<String, String> addresses) {
-        if (addresses.isEmpty() && !isKnownExceptionAlreadyLogged) {
+        if (addresses.isEmpty() && !isEmptyAddressListAlreadyLogged) {
             LOGGER.warning("No IP addresses found! Starting standalone.");
-            isKnownExceptionAlreadyLogged = true;
+            isEmptyAddressListAlreadyLogged = true;
         }
 
         LOGGER.fine(String.format("Found the following (private => public) addresses: %s", addresses));


### PR DESCRIPTION
This fixes the issue https://github.com/hazelcast/hazelcast-aws/issues/222

However, there is a problem to consider. The cause of this log output is empty address list. This is not mutually exclusive with the errors `NoCredentialsException` and `RestClientException`. If address list is empty and one of the exceptions is thrown, user only will be notified by the empty address list. Upon fixing the empty address issue, they will see the other exceptions. We could solve this issue by using either an integer or an array instead of a boolean but I am not sure if the case I mentioned is a real life problem.