### PR TITLE
Feature/windows support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <hazelcast.version>4.2</hazelcast.version>
 
         <junit.version>4.13.2</junit.version>
+        <apache.commons.version>3.12.0</apache.commons.version>
         <mockito.version>1.10.19</mockito.version>
         <log4j.version>1.2.17</log4j.version>
         <wiremock.version>2.27.2</wiremock.version>
@@ -227,6 +228,11 @@
             <scope>test</scope>
             <version>${hazelcast.version}</version>
             <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${apache.commons.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -114,8 +114,6 @@ public class AwsDiscoveryStrategyFactory
                 return uuid.startsWith("ec2") || uuid.startsWith("EC2");
             } catch (IOException e) {
                 e.printStackTrace();
-            } finally {
-
             }
         }
         return false;


### PR DESCRIPTION
Adding  uuidWithEc2PrefixWindows in case the EC2 instances are windows servers. I couldn't find any other locations for Linux dependencies but if so please let me know I'm happy to help add enhancement.