### PR TITLE
use IMDSv2 in 2.4.x

### DIFF
--- a/src/main/java/com/hazelcast/aws/utility/MetadataUtil.java
+++ b/src/main/java/com/hazelcast/aws/utility/MetadataUtil.java
@@ -23,6 +23,7 @@ import com.hazelcast.logging.Logger;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.concurrent.Callable;
@@ -36,6 +37,8 @@ public final class MetadataUtil {
      * See details at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html.
      */
     public static final String INSTANCE_METADATA_URI = "http://169.254.169.254/latest/meta-data/";
+    public static final String INSTANCE_METADATA_TOKEN_URI = "http://169.254.169.254/latest/api/token";
+    private static final Long TOKEN_LIFETIME_SECONDS = 21600L;
 
     /**
      * Post-fix URI to fetch IAM role details
@@ -48,8 +51,23 @@ public final class MetadataUtil {
     public static final String AVAILABILITY_ZONE_URI = "placement/availability-zone/";
 
     private static final ILogger LOGGER = Logger.getLogger(MetadataUtil.class);
+    private static String imdsV2Token = null;
+    private static long tokenLastFetchMillis = 0;    
 
     private MetadataUtil() {
+    }
+
+
+    public static String retrieveMetadataFromURI(String uri, int timeoutInSeconds) {
+        try {
+            HttpURLConnection connection = (HttpURLConnection) new URL(uri).openConnection();
+            connection.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(timeoutInSeconds));
+            connection.setRequestProperty("X-aws-ec2-metadata-token", getImdsV2Token(timeoutInSeconds));
+
+            return retrieveFromConnection(connection);
+        } catch (IOException io) {
+            throw new InvalidConfigurationException("Unable to lookup role in URI: " + uri, io);
+        }
     }
 
     /**
@@ -59,23 +77,19 @@ public final class MetadataUtil {
      * @param timeoutInSeconds timeout for the AWS service call
      * @return The content of the HTTP response, as a String. NOTE: This is NEVER null.
      */
-    public static String retrieveMetadataFromURI(String uri, int timeoutInSeconds) {
+    public static String retrieveFromConnection(HttpURLConnection connection) throws IOException {
         StringBuilder response = new StringBuilder();
 
         InputStreamReader is = null;
         BufferedReader reader = null;
         try {
-            URLConnection url = new URL(uri).openConnection();
-            url.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(timeoutInSeconds));
-            is = new InputStreamReader(url.getInputStream(), "UTF-8");
+            is = new InputStreamReader(connection.getInputStream(), "UTF-8");
             reader = new BufferedReader(is);
             String resp;
             while ((resp = reader.readLine()) != null) {
                 response = response.append(resp);
             }
             return response.toString();
-        } catch (IOException io) {
-            throw new InvalidConfigurationException("Unable to lookup role in URI: " + uri, io);
         } finally {
             if (is != null) {
                 try {
@@ -92,6 +106,25 @@ public final class MetadataUtil {
                 }
             }
         }
+    }
+
+    private static synchronized String getImdsV2Token(int timeoutInSeconds) {
+        if (imdsV2Token == null
+            || System.currentTimeMillis() - tokenLastFetchMillis >= TOKEN_LIFETIME_SECONDS * 1000) {
+                try {
+                    HttpURLConnection connection = (HttpURLConnection) new URL(INSTANCE_METADATA_TOKEN_URI).openConnection();
+                    connection.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(timeoutInSeconds));
+                    connection.setRequestMethod("PUT");
+                    connection.setRequestProperty(
+                        "X-aws-ec2-metadata-token-ttl-seconds", TOKEN_LIFETIME_SECONDS.toString());
+
+                    imdsV2Token = retrieveFromConnection(connection);
+                    tokenLastFetchMillis = System.currentTimeMillis();
+                } catch (IOException io) {
+                    throw new InvalidConfigurationException("Unable get new token for IMDSv2", io);
+                }
+        }
+        return imdsV2Token;
     }
 
     /**


### PR DESCRIPTION
This changes switches to the v2 EC2 metadata endpoint which is a security best practice.  This will close #240 for 2.4.x but not for all versions.  Thanks to @jkern888 for providing the gist with the code changes!